### PR TITLE
Drop plugins from rebar.config when using rebar2

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -10,5 +10,8 @@ case erlang:function_exported(rebar3, main, 1) of
     true -> % rebar3
         TravisConfig;
     false -> % rebar 2.x or older
-        lists:keystore(proto_opts, 1, TravisConfig, {proto_opts, [{src_dirs, []}]})
+        TravisConfig2 = lists:keystore(proto_opts, 1, TravisConfig, {proto_opts, [{src_dirs, []}]}),
+
+        % rebar3 plugins won't work in rebar2
+        lists:keydelete(plugins, 1, TravisConfig2)
 end.


### PR DESCRIPTION
This patch is intended to be able to use this library with rebar2.
This error happened when running `rebar get-deps`.

`WARN:  Remote origin url is Cloning into 'prometheus'...
Uncaught error in rebar_core: {'EXIT',
                               {function_clause,
                                [{code,which,
                                  [{rebar3_archive_plugin,"0.0.1"}],
                                  [{file,"code.erl"},{line,724}]},
                                 {rebar_core,'-plugin_modules/3-lc$^0/1-0-',
                                  1,
                                  [{file,"src/rebar_core.erl"},{line,570}]},
                                 {rebar_core,plugin_modules,3,
                                  [{file,"src/rebar_core.erl"},{line,570}]},
                                 {rebar_core,process_dir1,7,
                                  [{file,"src/rebar_core.erl"},{line,241}]},
                                 {rebar_core,process_each,5,
                                  [{file,"src/rebar_core.erl"},{line,348}]},
                                 {rebar_core,process_dir1,7,
                                  [{file,"src/rebar_core.erl"},{line,268}]},
                                 {rebar_core,process_each,5,
                                  [{file,"src/rebar_core.erl"},{line,348}]},
                                 {rebar_core,process_dir1,7,
                                  [{file,"src/rebar_core.erl"},{line,250}]}]}}
`

Regards