### PR TITLE
Added functions match_remove/1,3,4 to all metrics

### DIFF
--- a/src/metrics/prometheus_boolean.erl
+++ b/src/metrics/prometheus_boolean.erl
@@ -42,6 +42,9 @@
          remove/1,
          remove/2,
          remove/3,
+         match_remove/1,
+         match_remove/3,
+         match_remove/4,
          reset/1,
          reset/2,
          reset/3,
@@ -208,6 +211,27 @@ remove(Name, LabelValues) ->
 remove(Registry, Name, LabelValues) ->
   prometheus_metric:remove_labels(?TABLE, Registry, Name, LabelValues).
 
+%% @equiv match_remove(default, Name, [], [])
+match_remove(Name) ->
+  match_remove(default, Name, [], []).
+
+%% @equiv match_remove(default, Name, LMatchHead, LMatchCond)
+match_remove(Name, LMatchHead, LMatchCond) ->
+  match_remove(default, Name, LMatchHead, LMatchCond).
+
+%% @doc Remove the value of the boolean matched by `Registry', `Name',
+%% `LMatchHead' and `LMatchCond'.
+%%
+%% Raises `{unknown_metric, Registry, Name}' error if boolean with name `Name'
+%% can't be found in `Registry'.<br/>
+%% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
+%% mismatch.
+%% Returns the number of removed entries.
+%% @end
+match_remove(Registry, Name, LMatchHead, LMatchCond) ->
+  prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LMatchHead),
+  ets:select_delete(?TABLE, delete_match_spec(Registry, Name, LMatchHead, LMatchCond)).
+
 %% @equiv reset(default, Name, [])
 reset(Name) ->
   reset(default, Name, []).
@@ -295,7 +319,10 @@ collect_metrics(Name, {CLabels, Labels, Registry}) ->
 %%====================================================================
 
 deregister_select(Registry, Name) ->
-  [{{{Registry, Name, '_'}, '_'}, [], [true]}].
+  delete_match_spec(Registry, Name, '_', []).
+
+delete_match_spec(Registry, Name, LMatchHead, LMatchCond) ->
+  [{{{Registry, Name, LMatchHead}, '_'}, LMatchCond, [true]}].
 
 set_(Registry, Name, LabelValues, Value) ->
   case ets:update_element(?TABLE, {Registry, Name, LabelValues},

--- a/src/metrics/prometheus_histogram.erl
+++ b/src/metrics/prometheus_histogram.erl
@@ -49,6 +49,9 @@
          remove/1,
          remove/2,
          remove/3,
+         match_remove/1,
+         match_remove/3,
+         match_remove/4,
          reset/1,
          reset/2,
          reset/3,
@@ -299,6 +302,28 @@ remove(Registry, Name, LabelValues) ->
     _ -> true
   end.
 
+%% @equiv match_remove(default, Name, [], [])
+match_remove(Name) ->
+  match_remove(default, Name, [], []).
+
+%% @equiv match_remove(default, Name, LMatchHead, LMatchCond)
+match_remove(Name, LMatchHead, LMatchCond) ->
+  match_remove(default, Name, LMatchHead, LMatchCond).
+
+%% @doc Remove the value of the histogram matched by `Registry', `Name',
+%% `LMatchHead' and `LMatchCond'.
+%%
+%% Raises `{unknown_metric, Registry, Name}' error if histogram with name
+%% `Name' can't be found in `Registry'.<br/>
+%% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
+%% mismatch.
+%% Returns the number of removed entries.
+%% @end
+match_remove(Registry, Name, LMatchHead, LMatchCond) ->
+  MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LMatchHead),
+  Buckets = prometheus_metric:mf_data(MF),
+  ets:select_delete(?TABLE, delete_match_spec(Registry, Name, LMatchHead, LMatchCond, Buckets)).
+
 %% @equiv reset(default, Name, [])
 reset(Name) ->
   reset(default, Name, []).
@@ -529,9 +554,12 @@ load_all_values(Registry, Name, Bounds) ->
   ets:match(?TABLE, list_to_tuple(QuerySpec)).
 
 deregister_select(Registry, Name, Buckets) ->
+  delete_match_spec(Registry, Name, '_', [], Buckets).
+
+delete_match_spec(Registry, Name, LMatchHead, LMatchCond, Buckets) ->
   BoundCounters = lists:duplicate(length(Buckets), '_'),
-  MetricSpec = [{Registry, Name, '_', '_'}, '_', '_', '_'] ++ BoundCounters,
-  [{list_to_tuple(MetricSpec), [], [true]}].
+  MetricSpec = [{Registry, Name, LMatchHead, '_'}, '_', '_', '_'] ++ BoundCounters,
+  [{list_to_tuple(MetricSpec), LMatchCond, [true]}].
 
 delete_metrics(Registry, Buckets) ->
   BoundCounters = lists:duplicate(length(Buckets), '_'),

--- a/src/metrics/prometheus_quantile_summary.erl
+++ b/src/metrics/prometheus_quantile_summary.erl
@@ -49,6 +49,9 @@
          remove/1,
          remove/2,
          remove/3,
+         match_remove/1,
+         match_remove/3,
+         match_remove/4,
          reset/1,
          reset/2,
          reset/3,
@@ -233,6 +236,27 @@ remove(Registry, Name, LabelValues) ->
     _ -> true
   end.
 
+%% @equiv match_remove(default, Name, [], [])
+match_remove(Name) ->
+  match_remove(default, Name, [], []).
+
+%% @equiv match_remove(default, Name, LMatchHead, LMatchCond)
+match_remove(Name, LMatchHead, LMatchCond) ->
+  match_remove(default, Name, LMatchHead, LMatchCond).
+
+%% @doc Remove the value of the summary series matched by `Registry', `Name',
+%% `LMatchHead' and `LMatchCond'.
+%%
+%% Raises `{unknown_metric, Registry, Name}' error if boolean with name `Name'
+%% can't be found in `Registry'.<br/>
+%% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
+%% mismatch.
+%% Returns the number of removed entries.
+%% @end
+match_remove(Registry, Name, LMatchHead, LMatchCond) ->
+  prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LMatchHead),
+  ets:select_delete(?TABLE, delete_match_spec(Registry, Name, LMatchHead, LMatchCond)).
+
 %% @equiv reset(default, Name, [])
 reset(Name) ->
   reset(default, Name, []).
@@ -365,7 +389,10 @@ collect_metrics(Name, {CLabels, Labels, Registry, DU, Configuration}) ->
 %%====================================================================
 
 deregister_select(Registry, Name) ->
-  [{{{Registry, Name, '_', '_'}, '_', '_', '_', '_'}, [], [true]}].
+  delete_match_spec(Registry, Name, '_', []).
+
+delete_match_spec(Registry, Name, LMatchHead, LMatchCond) ->
+  [{{{Registry, Name, LMatchHead, '_'}, '_', '_', '_', '_'}, LMatchCond, [true]}].
 
 validate_summary_spec(Spec) ->
   Labels = prometheus_metric_spec:labels(Spec),

--- a/src/metrics/prometheus_summary.erl
+++ b/src/metrics/prometheus_summary.erl
@@ -41,6 +41,9 @@
          remove/1,
          remove/2,
          remove/3,
+         match_remove/1,
+         match_remove/3,
+         match_remove/4,
          reset/1,
          reset/2,
          reset/3,
@@ -228,6 +231,26 @@ remove(Registry, Name, LabelValues) ->
     _ -> true
   end.
 
+%% @equiv match_remove(default, Name, [], [])
+match_remove(Name) ->
+  match_remove(default, Name, [], []).
+
+%% @equiv match_remove(default, Name, LMatchHead, LMatchCond)
+match_remove(Name, LMatchHead, LMatchCond) ->
+  match_remove(default, Name, LMatchHead, LMatchCond).
+
+%% @doc Remove the value of the summary matched by `Registry', `Name',
+%% `LMatchHead' and `LMatchCond'.
+%%
+%% Raises `{unknown_metric, Registry, Name}' error if summary with name `Name'
+%% can't be found in `Registry'.<br/>
+%% Raises `{invalid_metric_arity, Present, Expected}' error if labels count
+%% mismatch.
+%% @end
+match_remove(Registry, Name, LMatchHead, LMatchCond) ->
+  prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LMatchHead),
+  ets:select_delete(?TABLE, delete_match_spec(Registry, Name, LMatchHead, LMatchCond)).
+
 %% @equiv reset(default, Name, [])
 reset(Name) ->
   reset(default, Name, []).
@@ -353,7 +376,10 @@ collect_metrics(Name, {CLabels, Labels, Registry, DU}) ->
 %%====================================================================
 
 deregister_select(Registry, Name) ->
-  [{{{Registry, Name, '_', '_'}, '_', '_', '_'}, [], [true]}].
+  delete_match_spec(Registry, Name, '_', []).
+
+delete_match_spec(Registry, Name, LMatchHead, LMatchCond) ->
+  [{{{Registry, Name, LMatchHead, '_'}, '_', '_', '_'}, LMatchCond, [true]}].
 
 validate_summary_spec(Spec) ->
   Labels = prometheus_metric_spec:labels(Spec),

--- a/test/eunit/metric/prometheus_histogram_tests.erl
+++ b/test/eunit/metric/prometheus_histogram_tests.erl
@@ -16,6 +16,7 @@ prometheus_format_test_() ->
     fun test_observe_duration_milliseconds/1,
     fun test_deregister/1,
     fun test_remove/1,
+    fun test_match_remove/1,
     fun test_default_value/1,
     fun test_values/1,
     fun test_collector1/1,
@@ -80,6 +81,10 @@ test_errors(_) ->
                  prometheus_histogram:remove(unknown_metric)),
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_histogram:remove(db_query_duration, [repo, db])),
+   ?_assertError({unknown_metric, default, unknown_metric},
+                 prometheus_histogram:match_remove(unknown_metric)),
+   ?_assertError({invalid_metric_arity, 2, 1},
+                 prometheus_histogram:match_remove(db_query_duration, [repo, db], [])),
 
    %% histogram specific errors
    ?_assertError({no_buckets, []},
@@ -286,6 +291,41 @@ test_remove(_) ->
    ?_assertEqual(undefined, ARValue2),
    ?_assertEqual(false, RResult3),
    ?_assertEqual(false, RResult4)].
+
+test_match_remove(_) ->
+  prometheus_histogram:new([{name, histogram},
+                            {buckets, [5, 10]},
+                            {labels, [pool]},
+                            {help, ""}]),
+  prometheus_histogram:new([{name, simple_histogram},
+                            {buckets, [5, 10]},
+                            {help, ""}]),
+
+  prometheus_histogram:observe(histogram, [mongodb], 1),
+  prometheus_histogram:observe(simple_histogram, 1),
+  prometheus_histogram:observe(histogram, [mongodb], 6),
+  prometheus_histogram:observe(simple_histogram, 6),
+
+  BRValue1 = prometheus_histogram:value(histogram, [mongodb]),
+  BRValue2 = prometheus_histogram:value(simple_histogram),
+
+  RResult1 = prometheus_histogram:match_remove(histogram, ['$1'], [{'=:=', '$1', mongodb}]),
+  RResult2 = prometheus_histogram:match_remove(simple_histogram),
+
+  ARValue1 = prometheus_histogram:value(histogram, [mongodb]),
+  ARValue2 = prometheus_histogram:value(simple_histogram),
+
+  RResult3 = prometheus_histogram:match_remove(histogram, ['$1'], [{'=:=', '$1', mongodb}]),
+  RResult4 = prometheus_histogram:match_remove(simple_histogram),
+
+  [?_assertEqual({[1, 1, 0], 7}, BRValue1),
+   ?_assertEqual({[1, 1, 0], 7}, BRValue2),
+   ?_assertEqual(1, RResult1),
+   ?_assertEqual(1, RResult2),
+   ?_assertEqual(undefined, ARValue1),
+   ?_assertEqual(undefined, ARValue2),
+   ?_assertEqual(0, RResult3),
+   ?_assertEqual(0, RResult4)].
 
 test_default_value(_) ->
   prometheus_histogram:new([{name, duration_histogram},

--- a/test/eunit/metric/prometheus_quantile_summary_tests.erl
+++ b/test/eunit/metric/prometheus_quantile_summary_tests.erl
@@ -17,6 +17,7 @@ prometheus_format_test_() ->
     fun test_observe_duration_milliseconds/1,
     fun test_deregister/1,
     fun test_remove/1,
+    fun test_match_remove/1,
     fun test_default_value/1,
     fun test_values/1,
     fun test_collector1/1,
@@ -71,6 +72,10 @@ test_errors(_) ->
                  prometheus_quantile_summary:remove(unknown_metric)),
    ?_assertError({invalid_metric_arity, 2, 1},
                  prometheus_quantile_summary:remove(db_query_duration, [repo, db])),
+   ?_assertError({unknown_metric, default, unknown_metric},
+                 prometheus_quantile_summary:match_remove(unknown_metric)),
+   ?_assertError({invalid_metric_arity, 2, 1},
+                 prometheus_quantile_summary:match_remove(db_query_duration, [repo, db], [])),
    %% summary specific errors
    ?_assertError({invalid_value, "qwe", "observe accepts only numbers"},
                  prometheus_quantile_summary:observe(orders_summary, "qwe")),
@@ -217,6 +222,34 @@ test_remove(_) ->
    ?_assertEqual(undefined, ARValue2),
    ?_assertEqual(false, RResult3),
    ?_assertEqual(false, RResult4)].
+
+test_match_remove(_) ->
+  prometheus_quantile_summary:new([{name, summary}, {labels, [pool]}, {help, ""}]),
+  prometheus_quantile_summary:new([{name, simple_summary}, {help, ""}]),
+
+  prometheus_quantile_summary:observe(summary, [mongodb], 1),
+  prometheus_quantile_summary:observe(simple_summary, 1),
+
+  BRValue1 = prometheus_quantile_summary:value(summary, [mongodb]),
+  BRValue2 = prometheus_quantile_summary:value(simple_summary),
+
+  RResult1 = prometheus_quantile_summary:match_remove(summary, ['$1'], [{'=:=', '$1', mongodb}]),
+  RResult2 = prometheus_quantile_summary:match_remove(simple_summary),
+
+  ARValue1 = prometheus_quantile_summary:value(summary, [mongodb]),
+  ARValue2 = prometheus_quantile_summary:value(simple_summary),
+
+  RResult3 = prometheus_quantile_summary:match_remove(summary, ['$1'], [{'=:=', '$1', mongodb}]),
+  RResult4 = prometheus_quantile_summary:match_remove(simple_summary),
+
+  [?_assertMatch({1, 1, _}, BRValue1),
+   ?_assertMatch({1, 1, _}, BRValue2),
+   ?_assertEqual(1, RResult1),
+   ?_assertEqual(1, RResult2),
+   ?_assertEqual(undefined, ARValue1),
+   ?_assertEqual(undefined, ARValue2),
+   ?_assertEqual(0, RResult3),
+   ?_assertEqual(0, RResult4)].
 
 test_default_value(_) ->
   prometheus_quantile_summary:new([{name, orders_summary},


### PR DESCRIPTION
match_remove can be used to selectively remove values for multiple
labels. The match head and match condition use the same rules as the
match specification parts of the same name.

This similar to #108, but can use arbitrary match conditions to select which labels to remove.