### PR TITLE
Prevent prometheus_quantile_summary crash without datapoints

### DIFF
--- a/src/metrics/prometheus_quantile_summary.erl
+++ b/src/metrics/prometheus_quantile_summary.erl
@@ -304,9 +304,12 @@ values(Registry, Name) ->
 
       MFValues = load_all_values(Registry, Name),
       ReducedMap = lists:foldl(
-        fun([L, C, S, QE], ResAcc) ->
-          {PrevCount, PrevSum, PrevQE} = maps:get(L, ResAcc, {0, 0, quantile(Configuration)}),
-          ResAcc#{L => {PrevCount + C, PrevSum + S, quantile_merge(PrevQE, QE)}}
+        fun
+          ([_, 0, _, _], ResAcc) ->
+            ResAcc; %% Ignore quantile evaluation if no data are provided
+          ([L, C, S, QE], ResAcc) ->
+            {PrevCount, PrevSum, PrevQE} = maps:get(L, ResAcc, {0, 0, quantile(Configuration)}),
+            ResAcc#{L => {PrevCount + C, PrevSum + S, quantile_merge(PrevQE, QE)}}
         end,
       #{},
       MFValues),
@@ -343,9 +346,12 @@ collect_metrics(Name, {CLabels, Labels, Registry, DU, Configuration}) ->
   #{quantiles := QNs} = Configuration,
   MFValues = load_all_values(Registry, Name),
   ReducedMap = lists:foldl(
-        fun([L, C, S, QE], ResAcc) ->
-          {PrevCount, PrevSum, PrevQE} = maps:get(L, ResAcc, {0, 0, quantile(Configuration)}),
-          ResAcc#{L => {PrevCount + C, PrevSum + S, quantile_merge(PrevQE, QE)}}
+        fun
+          ([_, 0, _, _], ResAcc) ->
+            ResAcc; %% Ignore quantile evaluation if no data are provided
+          ([L, C, S, QE], ResAcc) ->
+            {PrevCount, PrevSum, PrevQE} = maps:get(L, ResAcc, {0, 0, quantile(Configuration)}),
+            ResAcc#{L => {PrevCount + C, PrevSum + S, quantile_merge(PrevQE, QE)}}
         end,
       #{},
       MFValues),

--- a/test/eunit/metric/prometheus_quantile_summary_tests.erl
+++ b/test/eunit/metric/prometheus_quantile_summary_tests.erl
@@ -224,11 +224,16 @@ test_default_value(_) ->
                           {help, "Track orders count/total sum"}]),
   UndefinedValue = prometheus_quantile_summary:value(orders_summary, [electronics]),
 
+  [MF] = prometheus_collector:collect_mf_to_list(prometheus_quantile_summary),
+
+  #'MetricFamily'{metric = EmptyMetric} = MF,
+
   prometheus_quantile_summary:new([{name, something_summary},
                           {labels, []},
                           {help, ""}]),
   SomethingValue = prometheus_quantile_summary:value(something_summary),
   [?_assertEqual(undefined, UndefinedValue),
+   ?_assertMatch([], EmptyMetric),
    ?_assertMatch({0, 0, _}, SomethingValue)].
 
 test_values(_) ->


### PR DESCRIPTION
`quantile_estimator:quantile` fails before `prometheus_quantile_summary:observe/_` is performed.

```
prometheus_quantile_summary:declare([{name, test}, {labels, []}, {help, ""}]).
prometheus_text_format:format().
```
causes an exception:
```
** exception error: no function clause matching quantile_estimator:quantile(0.5,#Fun<quantile_estimator.1.111378939>,[],0,0,undefined) (/home/umberto/repos/prometheus.erl/_build/default/lib/quantile_estimator/src/quantile_estimator.erl, line 152)
     in function  prometheus_quantile_summary:'-quantile_values/2-lc$^0/1-0-'/2 (/home/umberto/repos/prometheus.erl/src/metrics/prometheus_quantile_summary.erl, line 476)
     in call from prometheus_quantile_summary:'-collect_metrics/2-fun-1-'/6 (/home/umberto/repos/prometheus.erl/src/metrics/prometheus_quantile_summary.erl, line 358)
     in call from prometheus_model_helpers:create_mf/5 (/home/umberto/repos/prometheus.erl/src/model/prometheus_model_helpers.erl, line 128)
     in call from prometheus_quantile_summary:'-collect_mf/2-lc$^0/1-0-'/3 (/home/umberto/repos/prometheus.erl/src/metrics/prometheus_quantile_summary.erl, line 336)
     in call from prometheus_quantile_summary:collect_mf/2 (/home/umberto/repos/prometheus.erl/src/metrics/prometheus_quantile_summary.erl, line 337)
     in call from prometheus_collector:collect_mf/3 (/home/umberto/repos/prometheus.erl/src/prometheus_collector.erl, line 156)
     in call from prometheus_registry:'-collect/2-lc$^0/1-0-'/3 (/home/umberto/repos/prometheus.erl/src/prometheus_registry.erl, line 86)
```
The suggested patch ignores the format operation for any quantile_summary metric without observations.
