### PR TITLE
Optimise startup time

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ Histogram also accepts `buckets` option. Please refer to respective modules docs
 
 ### Advanced
 
-You will need these modules only if you're writing custom collector for app/lib that can't be instrumented directly.
+You will need these modules only if you're writing a custom collector for an app/lib that can't be instrumented directly.
 
 - [`prometheus_collector`](https://github.com/deadtrickster/prometheus.erl/blob/master/doc/prometheus_collector.md) - common interface for collectors;
 - [`prometheus_format`](https://github.com/deadtrickster/prometheus.erl/blob/master/doc/prometheus_format.md) - common interface for exposition formats;
 - [`prometheus_model_helpers`](https://github.com/deadtrickster/prometheus.erl/blob/master/doc/prometheus_model_helpers.md) - provides API for working with underlying Prometheus models.
-You'll use that if you want to create custom collector.
+You'll use that if you want to create a custom collector.
 
 ## Build
 
@@ -198,29 +198,27 @@ You'll use that if you want to create custom collector.
 ## Configuration
 
 Prometheus.erl supports standard Erlang app configuration.
-- `collectors` - List of custom collectors modules to be registered automatically. If undefined list of all modules implementing `prometheus_collector` behaviour will be used.
-- `default_metrics` - List of metrics to be registered during app startup. Metric format: `{Type, Spec}` where `Type` is a metric type (counter, gauge, etc), `Spec` is a list to be passed to `Metric:declare/1`. Deprecated format `{Registry, Metric, Spec}` also supported.
+- `collectors` - List of custom collectors modules to be registered automatically.
+    Can be `all_loaded` in order to find all modules implementing the `prometheus_collector` behaviour.
+    Supports an "alias" option `default`, which will append all default collectors implemented in this library.
+    If undefined, the default collectors implemented in this library will be used.
+- `instrumenters` - List of custom instrumenter modules to be registered automatically.
+    Can be `all_loaded` in order to find all modules implementing the `prometheus_instrumenter` behaviour.
+    If undefined, none will be loaded.
+- `default_metrics` - List of metrics to be registered during app startup.
+    Metric format: `{Type, Spec}` where `Type` is a metric type (counter, gauge, etc),
+    `Spec` is a list to be passed to `Metric:declare/1`.
+    Deprecated format `{Registry, Metric, Spec}` also supported.
 
-Collectors config also supports "alias" option `default`. When used these collectors will be registered:
-<pre>
-prometheus_boolean,
-prometheus_counter,
-prometheus_gauge,
-prometheus_histogram,
-prometheus_mnesia_collector,
-prometheus_summary,
-prometheus_vm_memory_collector,
-prometheus_vm_statistics_collector,
-prometheus_vm_system_info_collector
-</pre>
 ## Collectors & Exporters Conventions
 
 ### Configuration
 
 All 3d-party libraries should be configured via `prometheus` app env.
 
-Exproters are responsible for maintianing scrape endpoint.
-Exporters usually tightly coupled with web server and are singletons. They should understand these keys:
+Exporters are responsible for maintaining scrape endpoint.
+Exporters are usually tightly coupled with the web server and are singletons.
+They should understand these keys:
  - `path` - url for scraping;
  - `format` - scrape format as module name i.e. `prometheus_text_format` or `prometheus_protobuf_format`.
 Exporter-specific options should be under `<exporter_name>_exporter` for erlang or `<Exporter_name>Exporter` for Elixir i.e. `PlugsExporter` or `elli_exporter`

--- a/README.md
+++ b/README.md
@@ -233,21 +233,3 @@ Their configuration should be under `<collector_name>_collector`for erlang or `<
 For Erlang: `prometheus_<name>_collector`/`prometheus_<name>_exporter`.
 
 For Elixir: `Prometheus.<name>Collector`/`Prometheus.<name>Exporter`.
-
-## Contributing
-
-Sections order:
-
-`Types -> Macros -> Callbacks -> Public API -> Deprecations -> Private Parts`
-
-install git precommit hook:
-
-```
-   ./bin/pre-commit.sh install
-```
-
-Pre-commit check can be skipped passing `--no-verify` option to git commit.
-
-## License
-
-MIT

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -9,7 +9,7 @@ ErlOpts =
     case list_to_integer(erlang:system_info(otp_release)) of
         N when N >= 27 ->
             %[warn_missing_doc, warn_missing_spec, warn_untyped_record | ErlOpts0];
-            [{with_ex_doc, true}, warn_missing_spec, warn_untyped_record | ErlOpts0];
+            [warn_missing_spec, warn_untyped_record | ErlOpts0];
         _ ->
             ErlOpts0
     end,

--- a/src/prometheus_collector.erl
+++ b/src/prometheus_collector.erl
@@ -128,7 +128,8 @@ Called when collector is deregistered. If collector is stateful you can put clea
 enabled_collectors() ->
     lists:usort(
         case application:get_env(prometheus, collectors) of
-            undefined -> all_known_collectors();
+            undefined -> ?DEFAULT_COLLECTORS;
+            {ok, all_loaded} -> all_known_collectors();
             {ok, Collectors} -> catch_default_collectors(Collectors)
         end
     ).

--- a/src/prometheus_instrumenter.erl
+++ b/src/prometheus_instrumenter.erl
@@ -19,7 +19,8 @@
 -spec enabled_instrumenters() -> [instrumenter()].
 enabled_instrumenters() ->
     case application:get_env(prometheus, instrumenters) of
-        undefined -> all_known_instrumenters();
+        undefined -> [];
+        {ok, all_loaded} -> all_known_instrumenters();
         {ok, Instrumenters} -> Instrumenters
     end.
 

--- a/test/eunit/prometheus_collector_tests.erl
+++ b/test/eunit/prometheus_collector_tests.erl
@@ -19,14 +19,20 @@
 
 collector_setup_test() ->
     prometheus:start(),
-    application:set_env(prometheus, collectors, [qwe]),
     try
+        application:set_env(prometheus, collectors, all_loaded),
+        ?assertMatch(?DEFAULT_COLLECTORS, prometheus_collector:enabled_collectors())
+    after
+        application:unset_env(prometheus, collectors)
+    end,
+    try
+        application:set_env(prometheus, collectors, [qwe]),
         ?assertMatch([qwe], prometheus_collector:enabled_collectors())
     after
         application:unset_env(prometheus, collectors)
     end,
-    application:set_env(prometheus, collectors, [qwe, default]),
     try
+        application:set_env(prometheus, collectors, [qwe, default]),
         C1 = ?DEFAULT_COLLECTORS ++ [qwe],
         ?assertMatch(C1, prometheus_collector:enabled_collectors())
     after

--- a/test/eunit/prometheus_instrumenter_tests.erl
+++ b/test/eunit/prometheus_instrumenter_tests.erl
@@ -4,14 +4,18 @@
 
 instrumenter_setup_test() ->
     prometheus:start(),
-    ?assertNotMatch(undefined, ets:info(prometheus_instrumenter_tests)),
-    application:set_env(prometheus, instrumenters, [qwe]),
+    ?assertMatch(undefined, ets:info(prometheus_instrumenter_tests)),
     try
+        application:set_env(prometheus, instrumenters, [qwe]),
         ?assertMatch([qwe], prometheus_instrumenter:enabled_instrumenters())
     after
         application:unset_env(prometheus, instrumenters)
     end,
-    ?assertMatch(
-        [prometheus_test_instrumenter],
-        prometheus_instrumenter:enabled_instrumenters()
-    ).
+    try
+        application:set_env(prometheus, instrumenters, all_loaded),
+        Expected = [prometheus_test_instrumenter],
+        ?assertMatch(Expected, prometheus_instrumenter:enabled_instrumenters())
+    after
+        application:unset_env(prometheus, instrumenters)
+    end,
+    ?assertMatch([], prometheus_instrumenter:enabled_instrumenters()).


### PR DESCRIPTION
Fixes #81. Overrides #150.

Note too that this is already fixed in RabbitMQ for example, so it won't break its use-case: https://github.com/rabbitmq/rabbitmq-server/commit/692b6f6661b0804be14a009b0ce10da20b4ec8b2

As in the last commit:

> This means that by default prometheus won't try to find all loaded
modules implementing a behaviour, as this can be a very expensive
operation (taking many seconds as has been seen in the field). If such
behaviour was desired, it'd require explicitly setting `all_loaded` for
instrumeters and collectors. The default is the most sane behaviour.