### PR TITLE
Quantile summaries

### DIFF
--- a/src/metrics/prometheus_summary.erl
+++ b/src/metrics/prometheus_summary.erl
@@ -10,7 +10,10 @@
 ?MODULEDOC("""
 Summary metric, to track the size of events.
 
-Example use cases for Summaries: - Response latency; - Request size; - Response size.
+Example use cases for Summaries:
+* Response latency;
+* Request size;
+* Response size.
 
 Example:
 
@@ -28,7 +31,6 @@ observe_request(Size) ->
 
 observe_response(Size) ->
     prometheus_summary:observe(response_size_bytes, Size).
-
 ```
 """).
 

--- a/test/.dir-locals.el
+++ b/test/.dir-locals.el
@@ -1,7 +1,0 @@
-((nil         . ((fill-column                  . 90)		 
-                 (eval                         . (turn-on-fci-mode))
-		 (erlang-indent-level           . 2)
-		 (flycheck-erlang-include-path . ("../../include"
-						  "../../../include"))
-                 (flycheck-erlang-library-path . ("../_build/default/lib/prometheus"
-                                                  "../_build/default/lib/prometheus/ebin")))))


### PR DESCRIPTION
Fixes #159 and #146 

As in the last commit:

> Note that the underlying algorithm for quantiles is not mergeable,
hence, it requires a linear strategy. However, precisely because it is
not generally mergeable, and it is also expensive, Prometheus generally
recommends using histograms on the client side, and it is left to the
Prometheus server to compute, merge, and aggregate, histograms,
recreating any required quantiles.
> It is left for the future to implement mergeable summaries, an idea
would be a DDSketch algorithm or any variant thereof.