### PR TITLE
Allow passing labels as maps, not just proplists

### DIFF
--- a/src/model/prometheus_model_helpers.erl
+++ b/src/model/prometheus_model_helpers.erl
@@ -336,8 +336,10 @@ fail with an error.
     Labels :: prometheus:labels().
 label_pairs(B) when is_binary(B) ->
     B;
-label_pairs(Labels) ->
-    lists:map(fun label_pair/1, Labels).
+label_pairs(Labels) when is_list(Labels) ->
+    lists:map(fun label_pair/1, Labels);
+label_pairs(Labels) when is_map(Labels) ->
+    lists:map(fun label_pair/1, maps:to_list(Labels)).
 
 ?DOC("""
 Creates `prometheus_model:`LabelPair'()' from \{Name, Value\} tuple.

--- a/src/prometheus.erl
+++ b/src/prometheus.erl
@@ -13,7 +13,7 @@
 -type label_value() :: term().
 -type label() :: {label_name(), label_value()}.
 -type pre_rendered_labels() :: binary().
--type labels() :: [label()] | pre_rendered_labels().
+-type labels() :: [label()] | #{label_name() => label_value()} | pre_rendered_labels().
 -type value() :: float() | integer() | undefined | infinity.
 -type prometheus_boolean() :: boolean() | number() | list() | undefined.
 -type gauge() :: value() | {value()} | {labels(), value()}.
@@ -42,6 +42,7 @@
 -export_type([
     label/0,
     labels/0,
+    label_name/0,
     label_value/0,
     value/0,
     gauge/0,

--- a/test/eunit/prometheus_model_helpers_tests.erl
+++ b/test/eunit/prometheus_model_helpers_tests.erl
@@ -40,6 +40,7 @@ gauge_metric_test() ->
     LName = <<"label">>,
     LValue = <<"value">>,
     Labels = [{LName, LValue}],
+    LabelsMap = #{LName => LValue},
     ?assertMatch(
         #'Metric'{
             label = NoLabels,
@@ -79,6 +80,32 @@ gauge_metric_test() ->
             }
         ],
         prometheus_model_helpers:gauge_metrics([{Labels, Value}])
+    ),
+    ?assertMatch(
+        #'Metric'{
+            label = [
+                #'LabelPair'{
+                    name = LName,
+                    value = LValue
+                }
+            ],
+            gauge = #'Gauge'{value = Value}
+        },
+        prometheus_model_helpers:gauge_metric(LabelsMap, Value)
+    ),
+    ?assertMatch(
+        [
+            #'Metric'{
+                label = [
+                    #'LabelPair'{
+                        name = LName,
+                        value = LValue
+                    }
+                ],
+                gauge = #'Gauge'{value = Value}
+            }
+        ],
+        prometheus_model_helpers:gauge_metrics([{LabelsMap, Value}])
     ).
 
 untyped_metric_test() ->
@@ -238,6 +265,7 @@ counter_metric_test() ->
     LName = <<"label">>,
     LValue = <<"value">>,
     Labels = [{LName, LValue}],
+    LabelsMap = #{LName => LValue},
     ?assertMatch(
         #'Metric'{
             label = NoLabels,
@@ -277,6 +305,18 @@ counter_metric_test() ->
             }
         ],
         prometheus_model_helpers:counter_metrics([{Labels, Value}])
+    ),
+    ?assertMatch(
+        #'Metric'{
+            label = [
+                #'LabelPair'{
+                    name = LName,
+                    value = LValue
+                }
+            ],
+            counter = #'Counter'{value = Value}
+        },
+        prometheus_model_helpers:counter_metric(LabelsMap, Value)
     ).
 
 summary_metric_test() ->
@@ -286,6 +326,7 @@ summary_metric_test() ->
     LName = <<"label">>,
     LValue = <<"value">>,
     Labels = [{LName, LValue}],
+    LabelsMap = #{LName => LValue},
     ?assertMatch(
         #'Metric'{
             label = NoLabels,
@@ -337,6 +378,21 @@ summary_metric_test() ->
             }
         ],
         prometheus_model_helpers:summary_metrics([{Labels, Count, Sum}])
+    ),
+    ?assertMatch(
+        #'Metric'{
+            label = [
+                #'LabelPair'{
+                    name = LName,
+                    value = LValue
+                }
+            ],
+            summary = #'Summary'{
+                sample_sum = Sum,
+                sample_count = Count
+            }
+        },
+        prometheus_model_helpers:summary_metric(LabelsMap, Count, Sum)
     ).
 
 histogram_metric_test() ->
@@ -347,6 +403,7 @@ histogram_metric_test() ->
     LName = <<"label">>,
     LValue = <<"value">>,
     Labels = [{LName, LValue}],
+    LabelsMap = #{LName => LValue},
     ?assertMatch(
         #'Metric'{
             label = NoLabels,
@@ -470,6 +527,39 @@ histogram_metric_test() ->
             }
         ],
         prometheus_model_helpers:histogram_metrics([{Labels, Buckets, Count, Sum}])
+    ),
+    ?assertMatch(
+        #'Metric'{
+            label = [
+                #'LabelPair'{
+                    name = LName,
+                    value = LValue
+                }
+            ],
+            histogram = #'Histogram'{
+                sample_sum = Sum,
+                sample_count = Count,
+                bucket = [
+                    #'Bucket'{
+                        cumulative_count = 1,
+                        upper_bound = 1
+                    },
+                    #'Bucket'{
+                        cumulative_count = 3,
+                        upper_bound = 2
+                    },
+                    #'Bucket'{
+                        cumulative_count = 4,
+                        upper_bound = 3
+                    },
+                    #'Bucket'{
+                        cumulative_count = 10,
+                        upper_bound = infinity
+                    }
+                ]
+            }
+        },
+        prometheus_model_helpers:histogram_metric(LabelsMap, Buckets, Count, Sum)
     ).
 
 fitler_undefined_metrics_test() ->


### PR DESCRIPTION
```
#{label1 => value1, labels2 => value2}
```

becomes equivalent of
```
[{label1, value1}, {label2, value2}]
```