### PR TITLE
Allow maps of metrics in create_mf/4

### DIFF
--- a/src/model/prometheus_model_helpers.erl
+++ b/src/model/prometheus_model_helpers.erl
@@ -94,9 +94,12 @@ Create Metric Family of `Type`, `Name` and `Help`.
     Type :: atom(),
     Metrics ::
         [prometheus_model:'Metric'()]
+        | #{#{prometheus:label_name() => prometheus:label_value()} => prometheus:value()}
         | prometheus_model:'Metric'()
         | prometheus:metrics(),
     MetricFamily :: prometheus_model:'MetricFamily'().
+create_mf(Name, Help, Type, Metrics) when is_map(Metrics) ->
+    create_mf(Name, Help, Type, maps:to_list(Metrics));
 create_mf(Name, Help, Type, Metrics0) ->
     Metrics = metrics_from_tuples(Type, Metrics0),
     #'MetricFamily'{

--- a/test/eunit/prometheus_model_helpers_tests.erl
+++ b/test/eunit/prometheus_model_helpers_tests.erl
@@ -616,6 +616,41 @@ create_mf_test() ->
             ]
         },
         create_mf(["ga", <<"uge1">>], "help", gauge, {[], g1_value})
+    ),
+
+    ?assertMatch(
+        #'MetricFamily'{
+            name = <<"create_mf_with_empty_map">>,
+            help = "help",
+            type = 'GAUGE',
+            metric = [
+                #'Metric'{
+                    label = [],
+                    gauge = #'Gauge'{value = 0.42}
+                }
+            ]
+        },
+        create_mf(<<"create_mf_with_empty_map">>, "help", gauge, #{#{} => 0.42})
+    ),
+
+    ?assertMatch(
+        #'MetricFamily'{
+            name = <<"create_mf_with_map">>,
+            help = "help",
+            type = 'GAUGE',
+            metric = [
+                #'Metric'{
+                    label = [
+                        #'LabelPair'{
+                            name = <<"l1">>,
+                            value = <<"v1">>
+                        }
+                    ],
+                    gauge = #'Gauge'{value = my_value}
+                }
+            ]
+        },
+        create_mf(<<"create_mf_with_map">>, "help", gauge, #{#{<<"l1">> => <<"v1">>} => my_value})
     ).
 
 collect_metrics(g1, _Data) ->


### PR DESCRIPTION
```
create_mf(<<"foo">>, "help", gauge, #{#{<<"l1">> => <<"v1">>} => my_value})
```

is equivalent with:
```
create_mf(<<"foo">>, "help", gauge, [{[{<<"l1">>, <<"v1">>}], my_value}])
```