### PR TITLE
Accept specs as maps as well as proplists

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -43,6 +43,7 @@
         {erl_opts, [nowarn_missing_spec]},
         {eunit_compile_opts, [{src_dirs, ["src", "test/eunit"]}]},
         {covertool, [{coverdata_files, ["ct.coverdata"]}]},
+        {cover_opts, [verbose, {min_coverage, 95}]},
         {cover_enabled, true},
         {cover_export_enabled, true},
         {cover_excl_mods, [prometheus_model, prometheus]}

--- a/src/prometheus_metric.erl
+++ b/src/prometheus_metric.erl
@@ -64,7 +64,17 @@ as well as handling metric labels and data.
 -type labels() :: [name()].
 
 ?DOC("Metric specification type").
--type spec() :: proplists:proplist().
+-type spec() ::
+    proplists:proplist()
+    | #{
+        name := name(),
+        help := help(),
+        registry => prometheus_registry:registry(),
+        constant_labels => [{atom(), term()}],
+        labels => labels(),
+        data => any(),
+        atom() => _
+    }.
 
 ?DOC("Inserts a new metric function into the table, fails if it already exists.").
 -callback new(Spec :: spec()) -> ok.

--- a/src/prometheus_sup.erl
+++ b/src/prometheus_sup.erl
@@ -78,7 +78,7 @@ maybe_create_table(Name, Options) ->
 declare_metric({Metric, Spec}) ->
     declare_metric(Metric, Spec);
 declare_metric({Registry, Metric, Spec}) ->
-    declare_metric(Metric, [{registry, Registry}] ++ Spec).
+    declare_metric(Metric, prometheus_metric_spec:add_value(registry, Registry, Spec)).
 
 declare_metric(counter, Spec) ->
     prometheus_counter:declare(Spec);

--- a/test/eunit/prometheus_default_metrics_tests.erl
+++ b/test/eunit/prometheus_default_metrics_tests.erl
@@ -16,6 +16,16 @@ default_metric_test() ->
             {help, ""},
             {buckets, [1, 2, 3]}
         ],
+        Spec2 = #{
+            name => Name,
+            help => "",
+            labels => [a, b]
+        },
+        Spec3 = #{
+            name => Name,
+            help => "",
+            some_other_value => [1, 2, 3]
+        },
 
         application:stop(prometheus),
         application:set_env(
@@ -25,6 +35,9 @@ default_metric_test() ->
                 {counter, Spec},
                 {gauge, Spec},
                 {qwe, summary, Spec1},
+                {summary, Spec2},
+                {summary, Spec3},
+                {with_maps, summary, Spec3},
                 {prometheus_histogram, Spec},
                 {boolean, Spec}
             ]
@@ -36,5 +49,6 @@ default_metric_test() ->
         ?assertEqual(false, prometheus_histogram:declare(Spec)),
         ?assertEqual(false, prometheus_boolean:declare(Spec))
     after
+        application:stop(prometheus),
         application:unset_env(prometheus, default_metrics)
     end.

--- a/test/eunit/prometheus_metric_spec_tests.erl
+++ b/test/eunit/prometheus_metric_spec_tests.erl
@@ -3,28 +3,46 @@
 -include_lib("eunit/include/eunit.hrl").
 
 get_value_test() ->
-    Spec = [{name, "qwe"}],
+    Spec1 = [{name, "qwe"}],
+    Spec2 = #{name => "qwe"},
 
     ?assertMatch(
         undefined,
-        prometheus_metric_spec:get_value(labels, Spec)
+        prometheus_metric_spec:get_value(labels, Spec1)
     ),
     ?assertMatch(
         [default],
-        prometheus_metric_spec:get_value(labels, Spec, [default])
+        prometheus_metric_spec:get_value(labels, Spec1, [default])
     ),
 
-    ?assertEqual("qwe", prometheus_metric_spec:get_value(name, Spec)).
+    ?assertMatch(
+        undefined,
+        prometheus_metric_spec:get_value(labels, Spec2)
+    ),
+    ?assertMatch(
+        [default],
+        prometheus_metric_spec:get_value(labels, Spec2, [default])
+    ),
+
+    ?assertEqual("qwe", prometheus_metric_spec:get_value(name, Spec1)),
+    ?assertEqual("qwe", prometheus_metric_spec:get_value(name, Spec2)).
 
 fetch_value_test() ->
-    Spec = [{name, "qwe"}],
+    Spec1 = [{name, "qwe"}],
+    Spec2 = #{name => "qwe"},
 
     ?assertError(
-        {missing_metric_spec_key, labels, Spec},
-        prometheus_metric_spec:fetch_value(labels, Spec)
+        {missing_metric_spec_key, labels, Spec1},
+        prometheus_metric_spec:fetch_value(labels, Spec1)
     ),
 
-    ?assertEqual("qwe", prometheus_metric_spec:fetch_value(name, Spec)).
+    ?assertError(
+        {missing_metric_spec_key, labels, Spec2},
+        prometheus_metric_spec:fetch_value(labels, Spec2)
+    ),
+
+    ?assertEqual("qwe", prometheus_metric_spec:fetch_value(name, Spec1)),
+    ?assertEqual("qwe", prometheus_metric_spec:fetch_value(name, Spec2)).
 
 validate_metric_name_test() ->
     ?assertError(


### PR DESCRIPTION
Following up on https://github.com/prometheus-erl/prometheus.erl/pull/179 and https://github.com/prometheus-erl/prometheus.erl/pull/180, also allow to pass specs as maps instead of only proplists. This also allows to define types for them.