### PR TITLE
Types for name, labels, and help inputs

### DIFF
--- a/src/metrics/prometheus_boolean.erl
+++ b/src/metrics/prometheus_boolean.erl
@@ -138,8 +138,10 @@ set(Name, Value) ->
     set(default, Name, [], Value).
 
 ?DOC(#{equiv => set(default, Name, LabelValues, Value)}).
--spec set(prometheus_metric:name(), prometheus_metric:labels(), prometheus:prometheus_boolean()) ->
-    ok.
+-spec set(Name, LabelValues, Value) -> ok when
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values(),
+    Value :: prometheus:prometheus_boolean().
 set(Name, LabelValues, Value) ->
     set(default, Name, LabelValues, Value).
 
@@ -167,7 +169,7 @@ Raises:
 -spec set(Registry, Name, LabelValues, Value) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: prometheus:prometheus_boolean().
 set(Registry, Name, LabelValues, Value) ->
     Value1 = prometheus_model_helpers:boolean_value(Value),
@@ -179,7 +181,7 @@ toggle(Name) ->
     toggle(default, Name, []).
 
 ?DOC(#{equiv => toggle(default, Name, LabelValues)}).
--spec toggle(prometheus_metric:name(), prometheus_metric:labels()) -> ok.
+-spec toggle(prometheus_metric:name(), prometheus_metric:label_values()) -> ok.
 toggle(Name, LabelValues) ->
     toggle(default, Name, LabelValues).
 
@@ -194,8 +196,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if boolean with named `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec toggle(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    ok.
+-spec toggle(Registry, Name, LabelValues) -> ok when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 toggle(Registry, Name, LabelValues) ->
     Key = {Registry, Name, LabelValues},
     Spec = {?BOOLEAN_POS, 1, 1, 0},
@@ -213,7 +217,7 @@ remove(Name) ->
     remove(default, Name, []).
 
 ?DOC(#{equiv => remove(default, Name, LabelValues)}).
--spec remove(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec remove(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 remove(Name, LabelValues) ->
     remove(default, Name, LabelValues).
 
@@ -225,8 +229,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if boolean with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec remove(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec remove(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 remove(Registry, Name, LabelValues) ->
     prometheus_metric:remove_labels(?TABLE, Registry, Name, LabelValues).
 
@@ -236,7 +242,7 @@ reset(Name) ->
     reset(default, Name, []).
 
 ?DOC(#{equiv => reset(default, Name, LabelValues)}).
--spec reset(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec reset(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 reset(Name, LabelValues) ->
     reset(default, Name, LabelValues).
 
@@ -248,8 +254,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if boolean with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec reset(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec reset(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 reset(Registry, Name, LabelValues) ->
     prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     ets:update_element(?TABLE, {Registry, Name, LabelValues}, {?BOOLEAN_POS, 0}).
@@ -260,7 +268,7 @@ value(Name) ->
     value(default, Name, []).
 
 ?DOC(#{equiv => value(default, Name, LabelValues)}).
--spec value(prometheus_metric:name(), prometheus_metric:labels()) -> boolean() | undefined.
+-spec value(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean() | undefined.
 value(Name, LabelValues) ->
     value(default, Name, LabelValues).
 
@@ -273,8 +281,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if boolean named `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec value(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean() | undefined.
+-spec value(Registry, Name, LabelValues) -> boolean() | undefined when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 value(Registry, Name, LabelValues) ->
     case ets:lookup(?TABLE, {Registry, Name, LabelValues}) of
         [{_Key, 0}] ->

--- a/src/metrics/prometheus_counter.erl
+++ b/src/metrics/prometheus_counter.erl
@@ -160,14 +160,14 @@ inc(Name) ->
 If the second argument is a list, equivalent to [inc(default, Name, LabelValues,
 1)](`inc/4`) otherwise equivalent to [inc(default, Name, [], Value)](`inc/4`).
 """).
--spec inc(prometheus_metric:name(), prometheus_metric:labels() | non_neg_integer()) -> ok.
+-spec inc(prometheus_metric:name(), prometheus_metric:label_values() | non_neg_integer()) -> ok.
 inc(Name, LabelValues) when is_list(LabelValues) ->
     inc(default, Name, LabelValues, 1);
 inc(Name, Value) ->
     inc(default, Name, [], Value).
 
 ?DOC(#{equiv => inc(default, Name, LabelValues, Value)}).
--spec inc(prometheus_metric:name(), prometheus_metric:labels(), non_neg_integer()) -> ok.
+-spec inc(prometheus_metric:name(), prometheus_metric:label_values(), non_neg_integer()) -> ok.
 inc(Name, LabelValues, Value) ->
     inc(default, Name, LabelValues, Value).
 
@@ -183,7 +183,7 @@ Raises:
 -spec inc(Registry, Name, LabelValues, Value) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: non_neg_integer() | float().
 inc(Registry, Name, LabelValues, Value) when is_integer(Value), Value >= 0 ->
     Key = key(Registry, Name, LabelValues),
@@ -215,7 +215,7 @@ remove(Name) ->
 
 ?DOC(#{equiv => remove(default, Name, LabelValues)}).
 ?DOC("Equivalent to [remove(default, Name, LabelValues)](`remove/3`).").
--spec remove(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec remove(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 remove(Name, LabelValues) ->
     remove(default, Name, LabelValues).
 
@@ -227,8 +227,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if counter with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec remove(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec remove(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 remove(Registry, Name, LabelValues) ->
     prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     List = [
@@ -246,7 +248,7 @@ reset(Name) ->
     reset(default, Name, []).
 
 ?DOC(#{equiv => reset(default, Name, LabelValues)}).
--spec reset(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec reset(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 reset(Name, LabelValues) ->
     reset(default, Name, LabelValues).
 
@@ -258,8 +260,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if counter with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec reset(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec reset(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 reset(Registry, Name, LabelValues) ->
     prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     Spec = [{?ISUM_POS, 0}, {?FSUM_POS, 0}],
@@ -279,7 +283,7 @@ value(Name) ->
     value(default, Name, []).
 
 ?DOC(#{equiv => value(default, Name, LabelValues)}).
--spec value(prometheus_metric:name(), prometheus_metric:labels()) -> number() | undefined.
+-spec value(prometheus_metric:name(), prometheus_metric:label_values()) -> number() | undefined.
 value(Name, LabelValues) ->
     value(default, Name, LabelValues).
 
@@ -292,8 +296,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if counter named `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec value(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    number() | undefined.
+-spec value(Registry, Name, LabelValues) -> number() | undefined when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 value(Registry, Name, LabelValues) ->
     prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     Spec = [{{{Registry, Name, LabelValues, '_'}, '$1', '$2'}, [], [{'+', '$1', '$2'}]}],

--- a/src/metrics/prometheus_gauge.erl
+++ b/src/metrics/prometheus_gauge.erl
@@ -172,7 +172,7 @@ set(Name, Value) ->
     set(default, Name, [], Value).
 
 ?DOC(#{equiv => set(default, Name, LabelValues, Value)}).
--spec set(prometheus_metric:name(), prometheus_metric:labels(), number()) -> ok.
+-spec set(prometheus_metric:name(), prometheus_metric:label_values(), number()) -> ok.
 set(Name, LabelValues, Value) ->
     set(default, Name, LabelValues, Value).
 
@@ -188,7 +188,7 @@ Raises:
 -spec set(Registry, Name, LabelValues, Value) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: undefined | number().
 set(Registry, Name, LabelValues, Value) when is_integer(Value) ->
     Update = [{?IGAUGE_POS, Value}, {?FGAUGE_POS, 0}],
@@ -226,14 +226,14 @@ inc(Name) ->
 If the second argument is a list, equivalent to [inc(default, Name, LabelValues, 1)](`inc/4`)
 otherwise equivalent to [inc(default, Name, [], Value)](`inc/4`).
 """).
--spec inc(prometheus_metric:name(), prometheus_metric:labels() | non_neg_integer()) -> ok.
+-spec inc(prometheus_metric:name(), prometheus_metric:label_values() | non_neg_integer()) -> ok.
 inc(Name, LabelValues) when is_list(LabelValues) ->
     inc(default, Name, LabelValues, 1);
 inc(Name, Value) ->
     inc(default, Name, [], Value).
 
 ?DOC(#{equiv => inc(default, Name, LabelValues, Value)}).
--spec inc(prometheus_metric:name(), prometheus_metric:labels(), non_neg_integer()) -> ok.
+-spec inc(prometheus_metric:name(), prometheus_metric:label_values(), non_neg_integer()) -> ok.
 inc(Name, LabelValues, Value) ->
     inc(default, Name, LabelValues, Value).
 
@@ -249,7 +249,7 @@ Raises:
 -spec inc(Registry, Name, LabelValues, Value) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: number().
 inc(Registry, Name, LabelValues, Value) when is_integer(Value) ->
     Key = key(Registry, Name, LabelValues),
@@ -282,7 +282,7 @@ dec(Name) ->
 If the second argument is a list, equivalent to [inc(default, Name, LabelValues, -1)](`inc/4`)
 otherwise equivalent to [inc(default, Name, [], -Value)](`inc/4`).
 """).
--spec dec(prometheus_metric:name(), prometheus_metric:labels() | number()) -> ok.
+-spec dec(prometheus_metric:name(), prometheus_metric:label_values() | number()) -> ok.
 dec(Name, LabelValues) when is_list(LabelValues) ->
     inc(default, Name, LabelValues, -1);
 dec(Name, Value) when is_number(Value) ->
@@ -291,7 +291,7 @@ dec(_Name, Value) ->
     erlang:error({invalid_value, Value, "dec accepts only numbers"}).
 
 ?DOC(#{equiv => inc(default, Name, LabelValues, -Value)}).
--spec dec(prometheus_metric:name(), prometheus_metric:labels(), number()) -> ok.
+-spec dec(prometheus_metric:name(), prometheus_metric:label_values(), number()) -> ok.
 dec(Name, LabelValues, Value) when is_number(Value) ->
     inc(default, Name, LabelValues, -Value);
 dec(_Name, _LabelValues, Value) ->
@@ -301,7 +301,7 @@ dec(_Name, _LabelValues, Value) ->
 -spec dec(Registry, Name, LabelValues, Value) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: number().
 dec(Registry, Name, LabelValues, Value) when is_number(Value) ->
     inc(Registry, Name, LabelValues, -Value);
@@ -314,7 +314,7 @@ set_to_current_time(Name) ->
     set_to_current_time(default, Name, []).
 
 ?DOC(#{equiv => set_to_current_time(default, Name, LabelValues)}).
--spec set_to_current_time(prometheus_metric:name(), prometheus_metric:labels()) -> ok.
+-spec set_to_current_time(prometheus_metric:name(), prometheus_metric:label_values()) -> ok.
 set_to_current_time(Name, LabelValues) ->
     set_to_current_time(default, Name, LabelValues).
 
@@ -329,7 +329,7 @@ Raises:
 -spec set_to_current_time(Registry, Name, LabelValues) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels().
+    LabelValues :: prometheus_metric:label_values().
 set_to_current_time(Registry, Name, LabelValues) ->
     set(Registry, Name, LabelValues, os:system_time(seconds)).
 
@@ -339,7 +339,7 @@ track_inprogress(Name, Fun) ->
     track_inprogress(default, Name, [], Fun).
 
 ?DOC(#{equiv => track_inprogress(default, Name, LabelValues, Fun)}).
--spec track_inprogress(prometheus_metric:name(), prometheus_metric:labels(), fun(() -> any())) ->
+-spec track_inprogress(prometheus_metric:name(), prometheus_metric:label_values(), fun(() -> any())) ->
     any().
 track_inprogress(Name, LabelValues, Fun) ->
     track_inprogress(default, Name, LabelValues, Fun).
@@ -357,7 +357,7 @@ Raises:
 -spec track_inprogress(Registry, Name, LabelValues, Fun) -> any() when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Fun :: fun(() -> any()).
 track_inprogress(Registry, Name, LabelValues, Fun) when is_function(Fun, 0) ->
     inc(Registry, Name, LabelValues, 1),
@@ -375,7 +375,8 @@ set_duration(Name, Fun) ->
     set_duration(default, Name, [], Fun).
 
 ?DOC(#{equiv => set_duration(default, Name, LabelValues, Fun)}).
--spec set_duration(prometheus_metric:name(), prometheus_metric:labels(), fun(() -> any())) -> any().
+-spec set_duration(prometheus_metric:name(), prometheus_metric:label_values(), fun(() -> any())) ->
+    any().
 set_duration(Name, LabelValues, Fun) ->
     set_duration(default, Name, LabelValues, Fun).
 
@@ -392,7 +393,7 @@ Raises:
 -spec set_duration(Registry, Name, LabelValues, Fun) -> any() when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Fun :: fun(() -> any()).
 set_duration(Registry, Name, LabelValues, Fun) when is_function(Fun, 0) ->
     Start = erlang:monotonic_time(),
@@ -410,7 +411,7 @@ remove(Name) ->
     remove(default, Name, []).
 
 ?DOC(#{equiv => remove(default, Name, LabelValues)}).
--spec remove(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec remove(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 remove(Name, LabelValues) ->
     remove(default, Name, LabelValues).
 
@@ -422,8 +423,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if gauge with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec remove(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec remove(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 remove(Registry, Name, LabelValues) ->
     prometheus_metric:remove_labels(?TABLE, Registry, Name, LabelValues).
 
@@ -433,7 +436,7 @@ reset(Name) ->
     reset(default, Name, []).
 
 ?DOC(#{equiv => reset(default, Name, LabelValues)}).
--spec reset(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec reset(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 reset(Name, LabelValues) ->
     reset(default, Name, LabelValues).
 
@@ -445,8 +448,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if gauge with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec reset(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec reset(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 reset(Registry, Name, LabelValues) ->
     prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     ets:update_element(?TABLE, {Registry, Name, LabelValues}, [{?IGAUGE_POS, 0}, {?FGAUGE_POS, 0}]).
@@ -457,7 +462,7 @@ value(Name) ->
     value(default, Name, []).
 
 ?DOC(#{equiv => value(default, Name, LabelValues)}).
--spec value(prometheus_metric:name(), prometheus_metric:labels()) -> number() | undefined.
+-spec value(prometheus_metric:name(), prometheus_metric:label_values()) -> number() | undefined.
 value(Name, LabelValues) ->
     value(default, Name, LabelValues).
 
@@ -473,8 +478,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if gauge named `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec value(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    number() | undefined.
+-spec value(Registry, Name, LabelValues) -> number() | undefined when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 value(Registry, Name, LabelValues) ->
     MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     DU = prometheus_metric:mf_duration_unit(MF),

--- a/src/metrics/prometheus_histogram.erl
+++ b/src/metrics/prometheus_histogram.erl
@@ -189,7 +189,7 @@ observe(Name, Value) ->
     observe(default, Name, [], Value).
 
 ?DOC(#{equiv => observe(default, Name, LabelValues, Value)}).
--spec observe(prometheus_metric:name(), prometheus_metric:labels(), number()) -> ok.
+-spec observe(prometheus_metric:name(), prometheus_metric:label_values(), number()) -> ok.
 observe(Name, LabelValues, Value) ->
     observe(default, Name, LabelValues, Value).
 
@@ -205,7 +205,7 @@ Raises:
 -spec observe(Registry, Name, LabelValues, Value) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: number().
 observe(Registry, Name, LabelValues, Value) when is_number(Value) ->
     observe_n(Registry, Name, LabelValues, Value, 1);
@@ -218,7 +218,8 @@ observe_n(Name, Value, Count) ->
     observe_n(default, Name, [], Value, Count).
 
 ?DOC(#{equiv => observe_n(default, Name, LabelValues, Value, Count)}).
--spec observe_n(prometheus_metric:name(), prometheus_metric:labels(), number(), integer()) -> ok.
+-spec observe_n(prometheus_metric:name(), prometheus_metric:label_values(), number(), integer()) ->
+    ok.
 observe_n(Name, LabelValues, Value, Count) ->
     observe_n(default, Name, LabelValues, Value, Count).
 
@@ -235,7 +236,7 @@ Raises:
 -spec observe_n(Registry, Name, LabelValues, Value, Count) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: number(),
     Count :: integer().
 observe_n(Registry, Name, LabelValues, Value, Count) when is_integer(Value), is_integer(Count) ->
@@ -277,7 +278,7 @@ during the observation.
 -spec pobserve(Registry, Name, LabelValues, Buckets, BucketPos, Value) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Buckets :: prometheus_buckets:buckets(),
     BucketPos :: integer(),
     Value :: number().
@@ -312,7 +313,7 @@ observe_duration(Name, Fun) ->
     observe_duration(default, Name, [], Fun).
 
 ?DOC(#{equiv => observe_duration(default, Name, LabelValues, Fun)}).
--spec observe_duration(prometheus_metric:name(), prometheus_metric:labels(), fun(() -> term())) ->
+-spec observe_duration(prometheus_metric:name(), prometheus_metric:label_values(), fun(() -> term())) ->
     term().
 observe_duration(Name, LabelValues, Fun) ->
     observe_duration(default, Name, LabelValues, Fun).
@@ -328,7 +329,7 @@ Raises:
 -spec observe_duration(Registry, Name, LabelValues, Fun) -> any() when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Fun :: fun(() -> any()).
 observe_duration(Registry, Name, LabelValues, Fun) when is_function(Fun, 0) ->
     Start = erlang:monotonic_time(),
@@ -346,7 +347,7 @@ remove(Name) ->
     remove(default, Name, []).
 
 ?DOC(#{equiv => remove(default, Name, LabelValues)}).
--spec remove(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec remove(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 remove(Name, LabelValues) ->
     remove(default, Name, LabelValues).
 
@@ -358,8 +359,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if histogram with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec remove(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec remove(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 remove(Registry, Name, LabelValues) ->
     prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     List = lists:flatten([
@@ -377,7 +380,7 @@ reset(Name) ->
     reset(default, Name, []).
 
 ?DOC(#{equiv => reset(default, Name, LabelValues)}).
--spec reset(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec reset(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 reset(Name, LabelValues) ->
     reset(default, Name, LabelValues).
 
@@ -389,8 +392,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if histogram with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec reset(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec reset(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 reset(Registry, Name, LabelValues) ->
     MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     Buckets = prometheus_metric:mf_data(MF),
@@ -417,7 +422,7 @@ value(Name) ->
     value(default, Name, []).
 
 ?DOC(#{equiv => value(default, Name, LabelValues)}).
--spec value(prometheus_metric:name(), prometheus_metric:labels()) ->
+-spec value(prometheus_metric:name(), prometheus_metric:label_values()) ->
     {number(), infinity | number()} | undefined.
 value(Name, LabelValues) ->
     value(default, Name, LabelValues).
@@ -434,8 +439,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if histogram named `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec value(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    {number(), infinity | number()} | undefined.
+-spec value(Registry, Name, LabelValues) -> {number(), infinity | number()} | undefined when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 value(Registry, Name, LabelValues) ->
     MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
 
@@ -461,7 +468,7 @@ buckets(Name) ->
     buckets(default, Name, []).
 
 ?DOC(#{equiv => buckets(default, Name, LabelValues)}).
--spec buckets(prometheus_metric:name(), prometheus_metric:labels()) -> [number()].
+-spec buckets(prometheus_metric:name(), prometheus_metric:label_values()) -> [number()].
 buckets(Name, LabelValues) ->
     buckets(default, Name, LabelValues).
 
@@ -469,7 +476,7 @@ buckets(Name, LabelValues) ->
 -spec buckets(Registry, Name, LabelValues) -> [number()] when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels().
+    LabelValues :: prometheus_metric:label_values().
 buckets(Registry, Name, LabelValues) ->
     MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     prometheus_metric:mf_data(MF).

--- a/src/metrics/prometheus_quantile_summary.erl
+++ b/src/metrics/prometheus_quantile_summary.erl
@@ -176,7 +176,7 @@ observe(Name, Value) ->
     observe(default, Name, [], Value).
 
 ?DOC(#{equiv => observe(default, Name, LabelValues, Value)}).
--spec observe(prometheus_metric:name(), prometheus_metric:labels(), number()) -> ok.
+-spec observe(prometheus_metric:name(), prometheus_metric:label_values(), number()) -> ok.
 observe(Name, LabelValues, Value) ->
     observe(default, Name, LabelValues, Value).
 
@@ -191,7 +191,7 @@ Raises:
 -spec observe(Registry, Name, LabelValues, Value) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: number().
 observe(Registry, Name, LabelValues, Value) when is_number(Value) ->
     Key = key(Registry, Name, LabelValues),
@@ -213,7 +213,7 @@ observe_duration(Name, Fun) ->
     observe_duration(default, Name, [], Fun).
 
 ?DOC(#{equiv => observe_duration(default, Name, LabelValues, Fun)}).
--spec observe_duration(prometheus_metric:name(), prometheus_metric:labels(), fun(() -> term())) ->
+-spec observe_duration(prometheus_metric:name(), prometheus_metric:label_values(), fun(() -> term())) ->
     term().
 observe_duration(Name, LabelValues, Fun) ->
     observe_duration(default, Name, LabelValues, Fun).
@@ -229,7 +229,7 @@ Raises:
 -spec observe_duration(Registry, Name, LabelValues, Value) -> T when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: fun(() -> T).
 observe_duration(Registry, Name, LabelValues, Fun) when is_function(Fun) ->
     Start = erlang:monotonic_time(),
@@ -247,7 +247,7 @@ remove(Name) ->
     remove(default, Name, []).
 
 ?DOC(#{equiv => remove(default, Name, LabelValues)}).
--spec remove(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec remove(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 remove(Name, LabelValues) ->
     remove(default, Name, LabelValues).
 
@@ -258,8 +258,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if summary with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec remove(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec remove(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 remove(Registry, Name, LabelValues) ->
     prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     case
@@ -280,7 +282,7 @@ reset(Name) ->
     reset(default, Name, []).
 
 ?DOC(#{equiv => reset(default, Name, LabelValues)}).
--spec reset(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec reset(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 reset(Name, LabelValues) ->
     reset(default, Name, LabelValues).
 
@@ -291,8 +293,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if summary with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec reset(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec reset(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 reset(Registry, Name, LabelValues) ->
     MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     Configuration = prometheus_metric:mf_data(MF),
@@ -316,7 +320,7 @@ value(Name) ->
     value(default, Name, []).
 
 ?DOC(#{equiv => value(default, Name, LabelValues)}).
--spec value(prometheus_metric:name(), prometheus_metric:labels()) ->
+-spec value(prometheus_metric:name(), prometheus_metric:label_values()) ->
     {integer(), number()} | undefined.
 value(Name, LabelValues) ->
     value(default, Name, LabelValues).
@@ -332,8 +336,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if summary named `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec value(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    {integer(), number()} | undefined.
+-spec value(Registry, Name, LabelValues) -> {integer(), number()} | undefined when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 value(Registry, Name, LabelValues) ->
     MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     DU = prometheus_metric:mf_duration_unit(MF),

--- a/src/metrics/prometheus_summary.erl
+++ b/src/metrics/prometheus_summary.erl
@@ -144,7 +144,7 @@ observe(Name, Value) ->
     observe(default, Name, [], Value).
 
 ?DOC(#{equiv => observe(default, Name, LabelValues, Value)}).
--spec observe(prometheus_metric:name(), prometheus_metric:labels(), number()) -> ok.
+-spec observe(prometheus_metric:name(), prometheus_metric:label_values(), number()) -> ok.
 observe(Name, LabelValues, Value) ->
     observe(default, Name, LabelValues, Value).
 
@@ -159,7 +159,7 @@ Raises:
 -spec observe(Registry, Name, LabelValues, Value) -> ok when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Value :: number().
 observe(Registry, Name, LabelValues, Value) when is_integer(Value) ->
     Key = key(Registry, Name, LabelValues),
@@ -189,7 +189,7 @@ observe_duration(Name, Fun) ->
     observe_duration(default, Name, [], Fun).
 
 ?DOC(#{equiv => observe_duration(default, Name, LabelValues, Fun)}).
--spec observe_duration(prometheus_metric:name(), prometheus_metric:labels(), fun(() -> term())) ->
+-spec observe_duration(prometheus_metric:name(), prometheus_metric:label_values(), fun(() -> term())) ->
     term().
 observe_duration(Name, LabelValues, Fun) ->
     observe_duration(default, Name, LabelValues, Fun).
@@ -205,7 +205,7 @@ Raises:
 -spec observe_duration(Registry, Name, LabelValues, Fun) -> any() when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
-    LabelValues :: prometheus_metric:labels(),
+    LabelValues :: prometheus_metric:label_values(),
     Fun :: fun(() -> any()).
 observe_duration(Registry, Name, LabelValues, Fun) when is_function(Fun) ->
     Start = erlang:monotonic_time(),
@@ -223,7 +223,7 @@ remove(Name) ->
     remove(default, Name, []).
 
 ?DOC(#{equiv => remove(default, Name, LabelValues)}).
--spec remove(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec remove(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 remove(Name, LabelValues) ->
     remove(default, Name, LabelValues).
 
@@ -234,8 +234,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if summary with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec remove(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec remove(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 remove(Registry, Name, LabelValues) ->
     prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     case
@@ -257,7 +259,7 @@ reset(Name) ->
     reset(default, Name, []).
 
 ?DOC(#{equiv => reset(default, Name, LabelValues)}).
--spec reset(prometheus_metric:name(), prometheus_metric:labels()) -> boolean().
+-spec reset(prometheus_metric:name(), prometheus_metric:label_values()) -> boolean().
 reset(Name, LabelValues) ->
     reset(default, Name, LabelValues).
 
@@ -268,8 +270,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if summary with name `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec reset(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    boolean().
+-spec reset(Registry, Name, LabelValues) -> boolean() when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 reset(Registry, Name, LabelValues) ->
     prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     case
@@ -293,7 +297,7 @@ value(Name) ->
     value(default, Name, []).
 
 ?DOC(#{equiv => value(default, Name, LabelValues)}).
--spec value(prometheus_metric:name(), prometheus_metric:labels()) ->
+-spec value(prometheus_metric:name(), prometheus_metric:label_values()) ->
     {integer(), number()} | undefined.
 value(Name, LabelValues) ->
     value(default, Name, LabelValues).
@@ -309,8 +313,10 @@ Raises:
 * `{unknown_metric, Registry, Name}` error if summary named `Name` can't be found in `Registry`.
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 """).
--spec value(prometheus_registry:registry(), prometheus_metric:name(), prometheus_metric:labels()) ->
-    {integer(), number()} | undefined.
+-spec value(Registry, Name, LabelValues) -> {integer(), number()} | undefined when
+    Registry :: prometheus_registry:registry(),
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values().
 value(Registry, Name, LabelValues) ->
     MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
     DU = prometheus_metric:mf_duration_unit(MF),

--- a/src/prometheus_metric.erl
+++ b/src/prometheus_metric.erl
@@ -29,7 +29,7 @@ as well as handling metric labels and data.
     remove_labels/4
 ]).
 
--export_type([name/0, value/0, labels/0, help/0, duration_unit/0, spec/0]).
+-export_type([name/0, value/0, labels/0, label_values/0, help/0, duration_unit/0, spec/0]).
 
 ?DOC("Metric name type").
 -type name() :: atom() | binary() | nonempty_string() | iolist().
@@ -60,8 +60,11 @@ as well as handling metric labels and data.
     | histogram_value()
     | undefined.
 
-?DOC("Metric labels type").
+?DOC("Metric label names type").
 -type labels() :: [name()].
+
+?DOC("Metric labels values, tagged or untagged, type").
+-type label_values() :: [prometheus:label_value()].
 
 ?DOC("Metric specification type").
 -type spec() ::

--- a/src/prometheus_metric_spec.erl
+++ b/src/prometheus_metric_spec.erl
@@ -157,7 +157,7 @@ fetch_value(Key, Spec) ->
 
 -spec validate_metric_name
     (atom()) -> atom();
-    (list()) -> list();
+    (string()) -> string();
     (binary()) -> binary().
 validate_metric_name(RawName) when is_atom(RawName) ->
     validate_metric_name(RawName, atom_to_list(RawName));
@@ -170,7 +170,7 @@ validate_metric_name(RawName) ->
 
 -spec validate_metric_name
     (atom(), list()) -> atom();
-    (list(), list()) -> list();
+    (string(), list()) -> string();
     (binary(), list()) -> binary().
 validate_metric_name(RawName, ListName) ->
     case io_lib:printable_unicode_list(ListName) of
@@ -190,7 +190,8 @@ validate_metric_name(RawName, ListName) ->
 
 -spec validate_metric_label_names(list()) -> prometheus_metric:labels().
 validate_metric_label_names(RawLabels) when is_list(RawLabels) ->
-    lists:map(fun validate_metric_label_name/1, RawLabels);
+    lists:foreach(fun validate_metric_label_name/1, RawLabels),
+    RawLabels;
 validate_metric_label_names(RawLabels) ->
     erlang:error({invalid_metric_labels, RawLabels, "not list"}).
 
@@ -223,7 +224,7 @@ validate_metric_label_name_content(RawName) ->
 
 -spec validate_metric_help(binary() | string()) -> binary() | string().
 validate_metric_help(RawHelp) when is_binary(RawHelp) ->
-    validate_metric_help(binary_to_list(RawHelp));
+    iolist_to_binary(validate_metric_help(binary_to_list(RawHelp)));
 validate_metric_help(RawHelp) when is_list(RawHelp) ->
     case io_lib:printable_unicode_list(RawHelp) of
         true -> RawHelp;

--- a/test/eunit/metric/prometheus_boolean_tests.erl
+++ b/test/eunit/metric/prometheus_boolean_tests.erl
@@ -220,8 +220,8 @@ test_values(_) ->
     [
         ?_assertEqual(
             [
-                {[{"name", mysql}], true},
-                {[{"name", postgres}], false}
+                {[{name, mysql}], true},
+                {[{name, postgres}], false}
             ],
             lists:sort(prometheus_boolean:values(default, fuse_state))
         )

--- a/test/eunit/metric/prometheus_counter_tests.erl
+++ b/test/eunit/metric/prometheus_counter_tests.erl
@@ -201,8 +201,8 @@ test_values(_) ->
     [
         ?_assertEqual(
             [
-                {[{"method", get}], 4},
-                {[{"method", post}], 56}
+                {[{method, get}], 4},
+                {[{method, post}], 56}
             ],
             lists:sort(prometheus_counter:values(default, http_requests_total))
         )

--- a/test/eunit/metric/prometheus_gauge_tests.erl
+++ b/test/eunit/metric/prometheus_gauge_tests.erl
@@ -429,8 +429,8 @@ test_values(_) ->
     [
         ?_assertEqual(
             [
-                {[{"pool", mongodb}], 10},
-                {[{"pool", postgres}], 13}
+                {[{pool, mongodb}], 10},
+                {[{pool, postgres}], 13}
             ],
             lists:sort(prometheus_gauge:values(default, pool_size))
         )

--- a/test/eunit/metric/prometheus_histogram_tests.erl
+++ b/test/eunit/metric/prometheus_histogram_tests.erl
@@ -526,7 +526,7 @@ test_values(_) ->
         ?_assertEqual(
             [
                 {
-                    [{"label", label1}],
+                    [{label, label1}],
                     [
                         {0.005, 0},
                         {0.01, 0},
@@ -544,7 +544,7 @@ test_values(_) ->
                     12
                 },
                 {
-                    [{"label", label2}],
+                    [{label, label2}],
                     [
                         {0.005, 0},
                         {0.01, 0},

--- a/test/eunit/metric/prometheus_quantile_summary_tests.erl
+++ b/test/eunit/metric/prometheus_quantile_summary_tests.erl
@@ -350,8 +350,8 @@ test_values(_) ->
     [
         ?_assertMatch(
             [
-                {[{"department", electronics}], 1, 765.5, _},
-                {[{"department", groceries}], 1, 112.3, _}
+                {[{department, electronics}], 1, 765.5, _},
+                {[{department, groceries}], 1, 112.3, _}
             ],
             lists:sort(prometheus_quantile_summary:values(default, orders_summary))
         )

--- a/test/eunit/metric/prometheus_summary_tests.erl
+++ b/test/eunit/metric/prometheus_summary_tests.erl
@@ -294,8 +294,8 @@ test_values(_) ->
     [
         ?_assertEqual(
             [
-                {[{"department", electronics}], 1, 765.5},
-                {[{"department", groceries}], 1, 112.3}
+                {[{department, electronics}], 1, 765.5},
+                {[{department, groceries}], 1, 112.3}
             ],
             lists:sort(prometheus_summary:values(default, orders_summary))
         )

--- a/test/eunit/prometheus_metric_spec_tests.erl
+++ b/test/eunit/prometheus_metric_spec_tests.erl
@@ -89,14 +89,14 @@ validate_metric_label_names_test() ->
     ),
 
     ?assertEqual(
-        ["_qwe", "weq123"],
+        [<<"_qwe">>, weq123],
         prometheus_metric_spec:validate_metric_label_names([
             <<"_qwe">>,
-            'weq123'
+            weq123
         ])
     ),
     ?assertEqual(
-        ["_qwe", "weq123"],
+        [<<"_qwe">>, "weq123"],
         prometheus_metric_spec:validate_metric_label_names([
             <<"_qwe">>,
             "weq123"
@@ -114,7 +114,7 @@ validate_metric_help_test() ->
     ),
 
     ?assertEqual("qwe_:qwe", prometheus_metric_spec:validate_metric_help("qwe_:qwe")),
-    ?assertEqual("qwe_:qwe", prometheus_metric_spec:validate_metric_help(<<"qwe_:qwe">>)).
+    ?assertEqual(<<"qwe_:qwe">>, prometheus_metric_spec:validate_metric_help(<<"qwe_:qwe">>)).
 
 constant_labels_test() ->
     ?assertEqual(


### PR DESCRIPTION
First commit is cosmetic and changes are mechanic, see only the change in `prometheus_metrics` to understand all the others. Second commit introduces another change that maybe is a breaking one? Thought I'd argue it's more of an implementation detail, but don't know how far a user can be looking into it. See commit messages for details.