### PR TITLE
Improvements

### DIFF
--- a/src/metrics/prometheus_gauge.erl
+++ b/src/metrics/prometheus_gauge.erl
@@ -226,14 +226,14 @@ inc(Name) ->
 If the second argument is a list, equivalent to [inc(default, Name, LabelValues, 1)](`inc/4`)
 otherwise equivalent to [inc(default, Name, [], Value)](`inc/4`).
 """).
--spec inc(prometheus_metric:name(), prometheus_metric:label_values() | non_neg_integer()) -> ok.
+-spec inc(prometheus_metric:name(), prometheus_metric:label_values() | number()) -> ok.
 inc(Name, LabelValues) when is_list(LabelValues) ->
     inc(default, Name, LabelValues, 1);
 inc(Name, Value) ->
     inc(default, Name, [], Value).
 
 ?DOC(#{equiv => inc(default, Name, LabelValues, Value)}).
--spec inc(prometheus_metric:name(), prometheus_metric:label_values(), non_neg_integer()) -> ok.
+-spec inc(prometheus_metric:name(), prometheus_metric:label_values(), number()) -> ok.
 inc(Name, LabelValues, Value) ->
     inc(default, Name, LabelValues, Value).
 
@@ -484,10 +484,12 @@ Raises:
     LabelValues :: prometheus_metric:label_values().
 value(Registry, Name, LabelValues) ->
     MF = prometheus_metric:check_mf_exists(?TABLE, Registry, Name, LabelValues),
-    DU = prometheus_metric:mf_duration_unit(MF),
     case ets:lookup(?TABLE, {Registry, Name, LabelValues}) of
-        [{_Key, IValue, FValue}] -> prometheus_time:maybe_convert_to_du(DU, sum(IValue, FValue));
-        [] -> undefined
+        [{_Key, IValue, FValue}] ->
+            DU = prometheus_metric:mf_duration_unit(MF),
+            prometheus_time:maybe_convert_to_du(DU, sum(IValue, FValue));
+        [] ->
+            undefined
     end.
 
 -spec values(prometheus_registry:registry(), prometheus_metric:name()) ->

--- a/src/prometheus.erl
+++ b/src/prometheus.erl
@@ -70,7 +70,12 @@ stop(_State) ->
 ?DOC(false).
 -spec start() -> ok | {error, term()}.
 start() ->
-    application:start(?MODULE).
+    case application:ensure_all_started(?MODULE) of
+        {ok, _} ->
+            ok;
+        Error ->
+            Error
+    end.
 
 ?DOC(false).
 -spec stop() -> ok | {error, term()}.

--- a/src/prometheus_buckets.erl
+++ b/src/prometheus_buckets.erl
@@ -130,9 +130,14 @@ linear(_Start, _Step, Count) when Count < 1 ->
 linear(Start, Step, Count) ->
     linear(Start, Step, Count, []).
 
--spec position(buckets(), number()) -> pos_integer().
+?DOC("""
+Find the first index that is greater than or equal to the given value.
+""").
+-spec position(buckets() | tuple(), number()) -> pos_integer().
 position(Buckets, Value) when is_list(Buckets), is_number(Value) ->
-    find_position(Buckets, Value, 0).
+    find_position(Buckets, Value, 0);
+position(Buckets, Value) when is_tuple(Buckets), 1 < tuple_size(Buckets), is_number(Value) ->
+    find_position_in_tuple(Buckets, Value, 1, tuple_size(Buckets)).
 
 linear(_Current, _Step, 0, Acc) ->
     lists:reverse(Acc);
@@ -155,7 +160,8 @@ try_to_maintain_integer_bounds(Bound) when is_float(Bound) ->
         false -> Bound
     end.
 
--spec find_position(buckets(), number(), non_neg_integer()) -> pos_integer().
+%% Find the first index that is greater than or equal to the given value.
+-spec find_position(buckets(), number(), non_neg_integer()) -> non_neg_integer().
 find_position([], _Value, _Pos) ->
     0;
 find_position([Bound | L], Value, Pos) ->
@@ -164,4 +170,21 @@ find_position([Bound | L], Value, Pos) ->
             Pos;
         false ->
             find_position(L, Value, Pos + 1)
+    end.
+
+%% Find the first index that is greater than or equal to the given value.
+-spec find_position_in_tuple(tuple(), number(), non_neg_integer(), pos_integer()) ->
+    non_neg_integer().
+find_position_in_tuple(Tuple, Value, Low, High) when Low =< High ->
+    Mid = Low + (High - Low) div 2,
+    case element(Mid, Tuple) of
+        Element when Element < Value ->
+            find_position_in_tuple(Tuple, Value, Mid + 1, High);
+        Element when Value =< Element ->
+            find_position_in_tuple(Tuple, Value, Low, Mid - 1)
+    end;
+find_position_in_tuple(Tuple, _Value, Low, _High) ->
+    case tuple_size(Tuple) < Low of
+        true -> 0;
+        false -> Low - 1
     end.

--- a/src/prometheus_time.erl
+++ b/src/prometheus_time.erl
@@ -155,14 +155,16 @@ maybe_convert_to_native(DU, Value) ->
         _ -> to_native(Value, DU)
     end.
 
--spec maybe_convert_to_du(duration_unit(), infinity | number()) -> infinity | number().
+-spec maybe_convert_to_du(undefined | duration_unit(), undefined | infinity | number()) ->
+    undefined | infinity | number().
+maybe_convert_to_du(undefined, Value) ->
+    Value;
+maybe_convert_to_du(_, undefined) ->
+    undefined;
 maybe_convert_to_du(_, infinity) ->
     infinity;
 maybe_convert_to_du(DU, Value) ->
-    case DU of
-        undefined -> Value;
-        _ -> from_native(Value, DU)
-    end.
+    from_native(Value, DU).
 
 %%====================================================================
 %% Private Parts

--- a/test/eunit/prometheus_buckets_tests.erl
+++ b/test/eunit/prometheus_buckets_tests.erl
@@ -2,6 +2,26 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+find_position_test_() ->
+    Buckets = prometheus_buckets:linear(1, 1, 10),
+    [
+        ?_assertEqual(0, prometheus_buckets:position(Buckets, 100))
+        | [
+            ?_assertEqual(N - 1, prometheus_buckets:position(Buckets, N))
+         || N <- lists:seq(1, 10)
+        ]
+    ].
+
+find_position_in_tuple_test_() ->
+    TupleBuckets = list_to_tuple(prometheus_buckets:linear(1, 1, 10)),
+    [
+        ?_assertEqual(0, prometheus_buckets:position(TupleBuckets, 100))
+        | [
+            ?_assertEqual(N - 1, prometheus_buckets:position(TupleBuckets, N))
+         || N <- lists:seq(1, 10)
+        ]
+    ].
+
 linear_errors_test() ->
     ?assertError(
         {invalid_value, 0, "Buckets count should be positive"},


### PR DESCRIPTION
Two things for histograms: when fetching for the buckets, lookup (and therefore only copy) the bucket config instead of the entire record). Second, keep buckets as a big tuple instead of a big list, which is smaller and therefore cheaper to copy, and also can apply binary search during the bucket lookup instead of linear search over a list.

Also for gauges, improve their performance and fix a bug about setting a gauge to undefined for integer or floats.

Extracting from https://github.com/prometheus-erl/prometheus.erl/pull/177