### PR TITLE
Upgrade OTP versions, supporting now only 26/27/28 and adapting to enhancements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ on:
 
 jobs:
   test:
-    name: OTP ${{matrix.otp}}
+    name: OTP ${{matrix.otp}} - rebar3 ${{matrix.rebar3}}
     strategy:
       matrix:
         otp: ['28', '27', '26']
-        rebar3: ['3.24']
+        rebar3: ['3.24', '3.25']
     runs-on: 'ubuntu-24.04'
     env:
       OTPVER: ${{ matrix.otp }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,8 @@ jobs:
     name: OTP ${{matrix.otp}}
     strategy:
       matrix:
-        otp: ['27', '26', '25']
-        rebar3: ['3.24.0']
+        otp: ['28', '27', '26']
+        rebar3: ['3.24']
     runs-on: 'ubuntu-24.04'
     env:
       OTPVER: ${{ matrix.otp }}
@@ -28,18 +28,17 @@ jobs:
       - run: rebar3 compile
       - run: rebar3 lint
       - run: rebar3 xref
+      - run: rebar3 dialyzer
       - run: rebar3 eunit
       - run: rebar3 fmt --check
-        if: ${{ matrix.otp == '27' }}
+        if: ${{ matrix.otp == '28' }}
       - run: rebar3 ex_doc
-        if: ${{ matrix.otp == '27' }}
-      - run: rebar3 dialyzer
-        if: ${{ matrix.otp == '27' }}
+        if: ${{ matrix.otp == '28' }}
       - run: rebar3 do cover, covertool generate
-        if: ${{ matrix.otp == '27' }}
+        if: ${{ matrix.otp == '28' }}
       - name: Upload code coverage
         uses: codecov/codecov-action@v5
-        if: ${{ matrix.otp == '27' }}
+        if: ${{ matrix.otp == '28' }}
         with:
           files: _build/test/covertool/prometheus.covertool.xml
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/rebar.config
+++ b/rebar.config
@@ -119,6 +119,7 @@
         filter => "*.erl",
         rules => [
             {elvis_text_style, line_length, #{limit => 120, skip_comments => false}},
+            {elvis_style, consistent_generic_type, #{preferred_type => term}},
             {elvis_style, invalid_dynamic_call, #{
                 ignore => [
                     prometheus_misc,
@@ -126,8 +127,8 @@
                     prometheus_sup
                 ]
             }},
-            {elvis_style, god_modules, #{limit => 54}},
-            {elvis_style, dont_repeat_yourself, #{min_complexity => 50}}
+            {elvis_style, god_modules, #{limit => 40}},
+            {elvis_style, dont_repeat_yourself, #{min_complexity => 15}}
         ],
         ruleset => erl_files
     },

--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,6 @@
 %% -*- mode: erlang -*-
+{minimum_otp_vsn, "26"}.
+
 {erl_opts, [
     debug_info,
     warn_unused_vars,
@@ -13,9 +15,8 @@
     warn_obsolete_guard,
     strict_validation,
     warn_export_vars,
-    warn_exported_vars,
+    warn_exported_vars
     %warn_missing_spec, warn_untyped_record, <- Added dynamically for OTP >=27 in rebar.config.script
-    {platform_define, "^(2|3)", recent_otp}
 ]}.
 
 {deps, [

--- a/src/collectors/vm/prometheus_vm_statistics_collector.erl
+++ b/src/collectors/vm/prometheus_vm_statistics_collector.erl
@@ -144,7 +144,6 @@ metrics() ->
             "except that real time is measured.", WallclockTime}
     ].
 
--ifdef(recent_otp).
 dirty_stat() ->
     try
         SO = erlang:system_info(schedulers_online),
@@ -156,10 +155,6 @@ dirty_stat() ->
     catch
         _:_ -> [undefined, undefined]
     end.
--else.
-dirty_stat() ->
-    [undefined, undefined].
--endif.
 
 enabled_metrics() ->
     application:get_env(prometheus, vm_statistics_collector_metrics, all).

--- a/src/metrics/prometheus_gauge.erl
+++ b/src/metrics/prometheus_gauge.erl
@@ -334,13 +334,15 @@ set_to_current_time(Registry, Name, LabelValues) ->
     set(Registry, Name, LabelValues, os:system_time(seconds)).
 
 ?DOC(#{equiv => track_inprogress(default, Name, [], Fun)}).
--spec track_inprogress(prometheus_metric:name(), fun(() -> any())) -> any().
+-spec track_inprogress(prometheus_metric:name(), fun(() -> dynamic())) -> dynamic().
 track_inprogress(Name, Fun) ->
     track_inprogress(default, Name, [], Fun).
 
 ?DOC(#{equiv => track_inprogress(default, Name, LabelValues, Fun)}).
--spec track_inprogress(prometheus_metric:name(), prometheus_metric:label_values(), fun(() -> any())) ->
-    any().
+-spec track_inprogress(Name, LabelValues, Fun) -> dynamic() when
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values(),
+    Fun :: fun(() -> dynamic()).
 track_inprogress(Name, LabelValues, Fun) ->
     track_inprogress(default, Name, LabelValues, Fun).
 
@@ -354,11 +356,11 @@ Raises:
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 * `{invalid_value, Value, Message}` if `Fun` isn't a function.
 """).
--spec track_inprogress(Registry, Name, LabelValues, Fun) -> any() when
+-spec track_inprogress(Registry, Name, LabelValues, Fun) -> dynamic() when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
     LabelValues :: prometheus_metric:label_values(),
-    Fun :: fun(() -> any()).
+    Fun :: fun(() -> dynamic()).
 track_inprogress(Registry, Name, LabelValues, Fun) when is_function(Fun, 0) ->
     inc(Registry, Name, LabelValues, 1),
     try
@@ -370,13 +372,15 @@ track_inprogress(_Registry, _Name, _LabelValues, Fun) ->
     erlang:error({invalid_value, Fun, "track_inprogress accepts only functions"}).
 
 ?DOC(#{equiv => set_duration(default, Name, [], Fun)}).
--spec set_duration(prometheus_metric:name(), fun(() -> any())) -> any().
+-spec set_duration(prometheus_metric:name(), fun(() -> dynamic())) -> dynamic().
 set_duration(Name, Fun) ->
     set_duration(default, Name, [], Fun).
 
 ?DOC(#{equiv => set_duration(default, Name, LabelValues, Fun)}).
--spec set_duration(prometheus_metric:name(), prometheus_metric:label_values(), fun(() -> any())) ->
-    any().
+-spec set_duration(Name, LabelValues, Fun) -> dynamic() when
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values(),
+    Fun :: fun(() -> dynamic()).
 set_duration(Name, LabelValues, Fun) ->
     set_duration(default, Name, LabelValues, Fun).
 
@@ -390,11 +394,11 @@ Raises:
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 * `{invalid_value, Value, Message}` if `Fun` isn't a function.
 """).
--spec set_duration(Registry, Name, LabelValues, Fun) -> any() when
+-spec set_duration(Registry, Name, LabelValues, Fun) -> dynamic() when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
     LabelValues :: prometheus_metric:label_values(),
-    Fun :: fun(() -> any()).
+    Fun :: fun(() -> dynamic()).
 set_duration(Registry, Name, LabelValues, Fun) when is_function(Fun, 0) ->
     Start = erlang:monotonic_time(),
     try

--- a/src/metrics/prometheus_quantile_summary.erl
+++ b/src/metrics/prometheus_quantile_summary.erl
@@ -208,13 +208,15 @@ observe(_Registry, _Name, _LabelValues, Value) ->
     erlang:error({invalid_value, Value, "observe accepts only numbers"}).
 
 ?DOC(#{equiv => observe_duration(default, Name, [], Fun)}).
--spec observe_duration(prometheus_metric:name(), fun(() -> term())) -> term().
+-spec observe_duration(prometheus_metric:name(), fun(() -> dynamic())) -> dynamic().
 observe_duration(Name, Fun) ->
     observe_duration(default, Name, [], Fun).
 
 ?DOC(#{equiv => observe_duration(default, Name, LabelValues, Fun)}).
--spec observe_duration(prometheus_metric:name(), prometheus_metric:label_values(), fun(() -> term())) ->
-    term().
+-spec observe_duration(Name, LabelValues, Value) -> dynamic() when
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values(),
+    Value :: fun(() -> dynamic()).
 observe_duration(Name, LabelValues, Fun) ->
     observe_duration(default, Name, LabelValues, Fun).
 
@@ -226,11 +228,11 @@ Raises:
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 * `{invalid_value, Value, Message}` if `Fun` isn't a function.
 """).
--spec observe_duration(Registry, Name, LabelValues, Value) -> T when
+-spec observe_duration(Registry, Name, LabelValues, Value) -> dynamic() when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
     LabelValues :: prometheus_metric:label_values(),
-    Value :: fun(() -> T).
+    Value :: fun(() -> dynamic()).
 observe_duration(Registry, Name, LabelValues, Fun) when is_function(Fun) ->
     Start = erlang:monotonic_time(),
     try

--- a/src/metrics/prometheus_summary.erl
+++ b/src/metrics/prometheus_summary.erl
@@ -184,13 +184,15 @@ observe(_Registry, _Name, _LabelValues, Value) ->
     erlang:error({invalid_value, Value, "observe accepts only numbers"}).
 
 ?DOC(#{equiv => observe_duration(default, Name, [], Fun)}).
--spec observe_duration(prometheus_metric:name(), fun(() -> term())) -> term().
+-spec observe_duration(prometheus_metric:name(), fun(() -> dynamic())) -> dynamic().
 observe_duration(Name, Fun) ->
     observe_duration(default, Name, [], Fun).
 
 ?DOC(#{equiv => observe_duration(default, Name, LabelValues, Fun)}).
--spec observe_duration(prometheus_metric:name(), prometheus_metric:label_values(), fun(() -> term())) ->
-    term().
+-spec observe_duration(Name, LabelValues, Fun) -> dynamic() when
+    Name :: prometheus_metric:name(),
+    LabelValues :: prometheus_metric:label_values(),
+    Fun :: fun(() -> dynamic()).
 observe_duration(Name, LabelValues, Fun) ->
     observe_duration(default, Name, LabelValues, Fun).
 
@@ -202,11 +204,11 @@ Raises:
 * `{invalid_metric_arity, Present, Expected}` error if labels count mismatch.
 * `{invalid_value, Value, Message}` if `Fun` isn't a function.
 """).
--spec observe_duration(Registry, Name, LabelValues, Fun) -> any() when
+-spec observe_duration(Registry, Name, LabelValues, Fun) -> dynamic() when
     Registry :: prometheus_registry:registry(),
     Name :: prometheus_metric:name(),
     LabelValues :: prometheus_metric:label_values(),
-    Fun :: fun(() -> any()).
+    Fun :: fun(() -> dynamic()).
 observe_duration(Registry, Name, LabelValues, Fun) when is_function(Fun) ->
     Start = erlang:monotonic_time(),
     try

--- a/src/prometheus.erl
+++ b/src/prometheus.erl
@@ -9,8 +9,8 @@
 
 -behaviour(application).
 
--type label_name() :: term().
--type label_value() :: term().
+-type label_name() :: dynamic().
+-type label_value() :: dynamic().
 -type label() :: {label_name(), label_value()}.
 -type pre_rendered_labels() :: binary().
 -type labels() :: [label()] | #{label_name() => label_value()} | pre_rendered_labels().
@@ -59,16 +59,16 @@
 -export([start/2, stop/1]).
 -export([start/0, stop/0]).
 
--spec start(application:start_type(), term()) -> supervisor:startlink_ret().
+-spec start(application:start_type(), dynamic()) -> supervisor:startlink_ret().
 start(_StartType, _StartArgs) ->
     prometheus_sup:start_link().
 
--spec stop(term()) -> ok.
+-spec stop(dynamic()) -> ok.
 stop(_State) ->
     ok.
 
 ?DOC(false).
--spec start() -> ok | {error, term()}.
+-spec start() -> ok | {error, dynamic()}.
 start() ->
     case application:ensure_all_started(?MODULE) of
         {ok, _} ->
@@ -78,6 +78,6 @@ start() ->
     end.
 
 ?DOC(false).
--spec stop() -> ok | {error, term()}.
+-spec stop() -> ok | {error, dynamic()}.
 stop() ->
     application:stop(?MODULE).

--- a/src/prometheus_collector.erl
+++ b/src/prometheus_collector.erl
@@ -91,10 +91,10 @@ create_gauge(Name, Help, Data) ->
 -type collector() :: atom().
 
 ?DOC("Data associated with a collector").
--type data() :: any().
+-type data() :: dynamic().
 
 ?DOC("Callback for `collect_mf/3`").
--type collect_mf_callback() :: fun((prometheus_model:'MetricFamily'()) -> any()).
+-type collect_mf_callback() :: fun((prometheus_model:'MetricFamily'()) -> dynamic()).
 
 ?DOC("Should call `Callback` for each `MetricFamily` of this collector").
 -callback collect_mf(Registry, Callback) -> ok when

--- a/src/prometheus_metric.erl
+++ b/src/prometheus_metric.erl
@@ -75,7 +75,7 @@ as well as handling metric labels and data.
         registry => prometheus_registry:registry(),
         constant_labels => [{atom(), term()}],
         labels => labels(),
-        data => any(),
+        data => term(),
         atom() => _
     }.
 
@@ -86,7 +86,7 @@ as well as handling metric labels and data.
 -callback declare(Spec :: spec()) -> boolean().
 
 ?DOC("Sets the default metric function for the module.").
--callback set_default(Registry, Name) -> any() when
+-callback set_default(Registry, Name) -> dynamic() when
     Registry :: prometheus_registry:registry(),
     Name :: name().
 
@@ -180,7 +180,7 @@ deregister_mf(Table, Registry, Name) ->
     end.
 
 ?DOC(false).
--spec check_mf_exists(Table, Registry, Name, LabelValues) -> any() | no_return() when
+-spec check_mf_exists(Table, Registry, Name, LabelValues) -> dynamic() | no_return() when
     Table :: atom(),
     Registry :: prometheus_registry:registry(),
     Name :: name(),
@@ -213,28 +213,28 @@ check_mf_exists(Table, Registry, Name) ->
     end.
 
 ?DOC(false).
--spec mf_labels(tuple()) -> any().
+-spec mf_labels(tuple()) -> dynamic().
 mf_labels(MF) ->
     {Labels, _} = element(2, MF),
     Labels.
 
 ?DOC(false).
--spec mf_constant_labels(tuple()) -> any().
+-spec mf_constant_labels(tuple()) -> dynamic().
 mf_constant_labels(MF) ->
     element(3, MF).
 
 ?DOC(false).
--spec mf_duration_unit(tuple()) -> any().
+-spec mf_duration_unit(tuple()) -> dynamic().
 mf_duration_unit(MF) ->
     element(4, MF).
 
 ?DOC(false).
--spec mf_data(tuple()) -> any().
+-spec mf_data(tuple()) -> dynamic().
 mf_data(MF) ->
     element(5, MF).
 
 ?DOC(false).
--spec metrics(term(), term()) -> any().
+-spec metrics(ets:table(), prometheus_registry:registry()) -> dynamic().
 metrics(Table, Registry) ->
     ets:match(Table, {{Registry, mf, '$1'}, '$2', '$3', '$4', '$5'}).
 

--- a/src/prometheus_metric_spec.erl
+++ b/src/prometheus_metric_spec.erl
@@ -55,7 +55,7 @@ help(Spec) ->
     validate_metric_help(Help).
 
 ?DOC(false).
--spec data(Spec :: prometheus_metric:spec()) -> any().
+-spec data(Spec :: prometheus_metric:spec()) -> dynamic().
 data(Spec) ->
     get_value(data, Spec).
 
@@ -102,7 +102,7 @@ duration_unit_from_spec(Spec) ->
     Help :: prometheus_metric:help(),
     CallTimeout :: [{atom(), term()}],
     DurationUnit :: prometheus_time:maybe_duration_unit(),
-    Data :: any().
+    Data :: dynamic().
 extract_common_params(Spec) ->
     Registry = registry(Spec),
     Name = name(Spec),
@@ -115,7 +115,7 @@ extract_common_params(Spec) ->
 
 ?DOC(false).
 ?DOC(#{equiv => get_value(Key, Spec, undefined)}).
--spec add_value(Key :: atom(), Value :: any(), Spec :: prometheus_metric:spec()) -> any().
+-spec add_value(Key :: atom(), Value :: dynamic(), Spec :: prometheus_metric:spec()) -> term().
 add_value(Key, Value, Spec) when is_list(Spec) ->
     [{Key, Value} | Spec];
 add_value(Key, Value, Spec) when is_map(Spec) ->
@@ -123,19 +123,19 @@ add_value(Key, Value, Spec) when is_map(Spec) ->
 
 ?DOC(false).
 ?DOC(#{equiv => get_value(Key, Spec, undefined)}).
--spec get_value(Key :: atom(), Spec :: prometheus_metric:spec()) -> any().
+-spec get_value(Key :: atom(), Spec :: prometheus_metric:spec()) -> term().
 get_value(Key, Spec) ->
     get_value(Key, Spec, undefined).
 
 ?DOC(false).
--spec get_value(Key :: atom(), Spec :: prometheus_metric:spec(), Default :: any()) -> any().
+-spec get_value(Key :: atom(), Spec :: prometheus_metric:spec(), Default :: dynamic()) -> dynamic().
 get_value(Key, Spec, Default) when is_list(Spec) ->
     proplists:get_value(Key, Spec, Default);
 get_value(Key, Spec, Default) when is_map(Spec) ->
     maps:get(Key, Spec, Default).
 
 ?DOC(false).
--spec fetch_value(Key :: atom(), Spec :: prometheus_metric:spec()) -> any() | no_return().
+-spec fetch_value(Key :: atom(), Spec :: prometheus_metric:spec()) -> dynamic() | no_return().
 fetch_value(Key, Spec) when is_list(Spec) ->
     case proplists:get_value(Key, Spec) of
         undefined ->

--- a/src/prometheus_misc.erl
+++ b/src/prometheus_misc.erl
@@ -43,7 +43,7 @@ does_module_implement_behaviour(Module, Behaviour) ->
     Behaviours = [Atts || {N, Atts} <- Attributes, (N =:= behaviour orelse N =:= behavior)],
     lists:member(Behaviour, lists:flatten(Behaviours)).
 
--spec module_attributes(atom()) -> [{atom(), any()}] | [].
+-spec module_attributes(atom()) -> [{atom(), term()}] | [].
 module_attributes(Module) ->
     try
         Module:module_info(attributes)

--- a/src/prometheus_registry.erl
+++ b/src/prometheus_registry.erl
@@ -43,7 +43,7 @@ from batch jobs.
 -type registry() :: atom().
 
 -type collect_callback() ::
-    fun((registry(), prometheus_collector:collector()) -> any()).
+    fun((registry(), prometheus_collector:collector()) -> dynamic()).
 
 -define(TABLE, ?PROMETHEUS_REGISTRY_TABLE).
 

--- a/src/prometheus_sup.erl
+++ b/src/prometheus_sup.erl
@@ -51,7 +51,7 @@ register_collectors() ->
 register_metrics() ->
     [declare_metric(Decl) || Decl <- default_metrics()].
 
--spec register_metrics([term()]) -> [boolean()].
+-spec register_metrics([dynamic()]) -> [boolean()].
 register_metrics(Metrics) ->
     DefaultMetrics0 = default_metrics(),
     DefaultMetrics1 = lists:usort(DefaultMetrics0 ++ Metrics),


### PR DESCRIPTION
Takes advantage of `dynamic()` typing as well as of `ets:lookup_element/4`.

Tagging everyone as it might be a more "controversial" change.