### PR TITLE
Use write_concurrency=auto for better scalability

### DIFF
--- a/src/prometheus_sup.erl
+++ b/src/prometheus_sup.erl
@@ -34,12 +34,12 @@ init([]) ->
 create_tables() ->
     Tables = [
         {?PROMETHEUS_REGISTRY_TABLE, [bag, {read_concurrency, true}]},
-        {?PROMETHEUS_COUNTER_TABLE, [{write_concurrency, true}]},
-        {?PROMETHEUS_GAUGE_TABLE, [{write_concurrency, true}]},
-        {?PROMETHEUS_SUMMARY_TABLE, [{write_concurrency, true}]},
-        {?PROMETHEUS_QUANTILE_SUMMARY_TABLE, [{write_concurrency, true}]},
-        {?PROMETHEUS_HISTOGRAM_TABLE, [{read_concurrency, true}, {write_concurrency, true}]},
-        {?PROMETHEUS_BOOLEAN_TABLE, [{write_concurrency, true}]}
+        {?PROMETHEUS_COUNTER_TABLE, [{write_concurrency, auto}]},
+        {?PROMETHEUS_GAUGE_TABLE, [{write_concurrency, auto}]},
+        {?PROMETHEUS_SUMMARY_TABLE, [{write_concurrency, auto}]},
+        {?PROMETHEUS_QUANTILE_SUMMARY_TABLE, [{write_concurrency, auto}]},
+        {?PROMETHEUS_HISTOGRAM_TABLE, [{read_concurrency, true}, {write_concurrency, auto}]},
+        {?PROMETHEUS_BOOLEAN_TABLE, [{write_concurrency, auto}]}
     ],
     [maybe_create_table(Name, Options) || {Name, Options} <- Tables],
     ok.


### PR DESCRIPTION
Benchmarks generally show better scalability as the parallelism increases, on my 12CPU hardware it is already visible:

<img width="1185" alt="image" src="https://github.com/user-attachments/assets/9849b0e1-47e2-4486-b2bb-7556e4a61af7" />

`auto` is available since OTP25, so we're good to go version-wise.
