### PR TITLE
Reduce garbage generation in `prometheus_text_format`

### DIFF
--- a/src/formats/prometheus_text_format.erl
+++ b/src/formats/prometheus_text_format.erl
@@ -289,12 +289,11 @@ escape_label_char(X) ->
 
 ?DOC(false).
 -spec has_special_char(binary()) -> boolean().
-has_special_char(<<C:8, _/bitstring>>) when C =:= $\\; C =:= $\n; C =:= $" ->
-    true;
-has_special_char(<<_:8, Rest/bitstring>>) ->
-    has_special_char(Rest);
-has_special_char(<<>>) ->
-    false.
+has_special_char(Subject) when is_binary(Subject) ->
+    %% See prometheus_sup:setup_persistent_terms/0.
+    %% Pattern checks for backslash, linefeed or double quote characters.
+    Pattern = persistent_term:get(prometheus_text_format_escape_pattern),
+    binary:match(Subject, Pattern) /= nomatch.
 
 ?DOC(false).
 escape_string(Fun, Str) when is_binary(Str) ->

--- a/src/prometheus_sup.erl
+++ b/src/prometheus_sup.erl
@@ -25,6 +25,7 @@ init([]) ->
     register_collectors(),
     register_metrics(),
     setup_instrumenters(),
+    setup_persistent_terms(),
     {ok, {{one_for_one, 5, 1}, []}}.
 
 %%====================================================================
@@ -92,3 +93,8 @@ declare_metric(boolean, Spec) ->
     prometheus_boolean:declare(Spec);
 declare_metric(Other, Spec) ->
     Other:declare(Spec).
+
+setup_persistent_terms() ->
+    %% See prometheus_text_format:has_special_char/1.
+    Pattern = binary:compile_pattern([<<$\\>>, <<$\n>>, <<$">>]),
+    ok = persistent_term:put(prometheus_text_format_escape_pattern, Pattern).


### PR DESCRIPTION
This is a somewhat small set of patches to `prometheus_text_format` which aim to reduce garbage creation during registry formatting. Reducing garbage creation drives down the cost to the VM of scraping large registries - both in terms of peak memory allocation and also the work that the garbage collector must do.

With these changes I see reduction in allocation reported by `tprof` in a stress test of one of RabbitMQ's most expensive registries. In a test against single-instance RabbitMQ brokers on EC2 instances this saves a noticeable amount of peak memory and reduces CPU utilization significantly.

<details><summary>tprof testing instructions</summary>

1. Clone `https://github.com/rabbitmq/rabbitmq-server`
2. `cd rabbitmq-server`
3. `make deps`
4. `make run-broker`
5. In another terminal in the `rabbitmq-server` repo, `sbin/rabbitmqctl import_definitions path/to/100k-classic-queues.json` pointing to [this definitions file](https://github.com/rabbitmq/sample-configs/blob/main/queues/100k-classic-queues.json).
6. In the shell from the `make run-broker` terminal, start `tprof` tracing for new processes: `tprof:start(#{type => call_memory}), tprof:enable_trace(new), tprof:set_pattern('_', '_', '_').`
7. In another terminal scrape the expensive endpoint: `curl -v localhost:15692/metrics/per-object --output /dev/null`
8. When that's done, collect and format the sample: `tprof:format(tprof:inspect(tprof:collect())).`

To test this change, <kbd>Ctrl</kbd><kbd>c</kbd> twice out of `make broker`, `cd deps/prometheus` and check out this branch. Then `rm -rf ebin` in that directory, `cd ../../` and repeat steps 4, 6, 7 and 8 again (skipping definitions import).

---

</details>

<details><summary>Registry collection tprof measurement before this change...</summary>

```
****** Process <0.301089.0>  --  100.00% of total *** 
FUNCTION                                                                                   CALLS      WORDS    PER CALL  [    %]
... removed everything less than 1% ...
prometheus_text_format:render_labels/1                                                   2308195    1944642        0.84  [ 1.01]
erlang:atom_to_binary/2                                                                   651584    2375647        3.65  [ 1.23]
prometheus_rabbitmq_core_metrics_collector:'-emit_queue_info/3-fun-0-'/3                  100000    2500000       25.00  [ 1.29]
prometheus_model_helpers:counter_metric/2                                                 301325    3615900       12.00  [ 1.87]
prometheus_text_format:'-render_labels/1-fun-0-'/2                                        321434    4178642       13.00  [ 2.16]
prometheus_rabbitmq_core_metrics_collector:'-collect_metrics/2-lc$^1/1-0-'/2             2300145    4400076        1.91  [ 2.28]
prometheus_model_helpers:'-metrics_from_tuples/2-lc$^0/1-0-'/2                           2308456    4616300        2.00  [ 2.39]
lists:'-filter/2-lc$^0/1-0-'/2                                                           2408461    4816304        2.00  [ 2.49]
erlang:integer_to_binary/1                                                               2206892    6620701        3.00  [ 3.43]
prometheus_rabbitmq_core_metrics_collector:label/1                                       2200038   11000022        5.00  [ 5.69]
prometheus_rabbitmq_core_metrics_collector:'-collect_metrics/2-lc$^0/1-1-'/2             2300145   11500190        5.00  [ 5.95]
prometheus_text_format:'-emit_mf_metrics/2-fun-0-'/3                                     2308150   11541419        5.00  [ 5.97]
prometheus_model_helpers:gauge_metric/2                                                  2006812   24081744       12.00  [12.47]
prometheus_text_format:has_special_char/1                                               23475329   24147190        1.03  [12.50]
prometheus_text_format:render_series/3                                                   2308200   32511401       14.09  [16.83]
ets:match_object/2                                                                            19   38406095  2021373.42  [19.88]
                                                                                                  193184463              [100.0]
```

---

</details>

<details><summary>Registry collection tprof measurement after this change...</summary>

```
****** Process <0.401000.0>  --  99.99% of total *** 
FUNCTION                                                                                  CALLS      WORDS    PER CALL  [    %]
... removed everything less than 1% ...
prometheus_model_helpers:label_pair/1                                                    429393    1717572        4.00  [ 1.16]
prometheus_text_format:render_labels/1                                                  2308195    1944642        0.84  [ 1.32]
erlang:atom_to_binary/2                                                                  651584    2375647        3.65  [ 1.61]
prometheus_rabbitmq_core_metrics_collector:'-emit_queue_info/3-fun-0-'/3                 100000    2500000       25.00  [ 1.69]
prometheus_model_helpers:counter_metric/2                                                301325    3615900       12.00  [ 2.45]
prometheus_text_format:'-render_labels/1-fun-0-'/2                                       321434    4178642       13.00  [ 2.83]
prometheus_rabbitmq_core_metrics_collector:'-collect_metrics/2-lc$^1/1-0-'/2            2300145    4400076        1.91  [ 2.98]
prometheus_model_helpers:'-metrics_from_tuples/2-lc$^0/1-0-'/2                          2308456    4616300        2.00  [ 3.13]
lists:'-filter/2-lc$^0/1-0-'/2                                                          2408461    4816304        2.00  [ 3.26]
erlang:integer_to_binary/1                                                              2206892    6620705        3.00  [ 4.49]
prometheus_rabbitmq_core_metrics_collector:label/1                                      2200038   11000022        5.00  [ 7.45]
prometheus_rabbitmq_core_metrics_collector:'-collect_metrics/2-lc$^0/1-1-'/2            2300145   11500190        5.00  [ 7.79]
prometheus_text_format:render_series/4                                                  2308200   11541000        5.00  [ 7.82]
prometheus_text_format:render_value/2                                                   2308200   11543618        5.00  [ 7.82]
prometheus_model_helpers:gauge_metric/2                                                 2006812   24081744       12.00  [16.32]
ets:match_object/2                                                                           19   38406095  2021373.42  [26.02]
                                                                                                 147597866              [100.0]
```

---

</details>

So with this change, the Cowboy request process in charge of this endpoint allocates `147_597_866` words instead of `193_184_463`, a reduction of `45_586_597` words or 23.6%.

<details><summary>Stress-testing on EC2...</summary>

On EC2 I have two `m7g.xlarge` instances running RabbitMQ: `galactica` which carries this change and `kestrel` which uses `prometheus` at v5.1.1 (latest version RabbitMQ has adopted). A third instance `curl`s these instances at an interval of two seconds with this script:

```sh
#! /usr/bin/env bash

N=600
SLEEP=2
for i in $(seq 1 $N)
do
  echo "Sleeping ${SLEEP}s... ($i / $N)"
  sleep $SLEEP
  echo "Ask for metrics from $1... ($i / $N)"
  curl -s "http://$1:15692/metrics/per-object" --output /dev/null &
done

wait
```

This asynchronously fires off a scrape request every two seconds for twenty minutes. The third node runs this script against both `galactica` and `kestrel` at the same time. The third node also scrapes these nodes' `node_exporter` metrics and RabbitMQ prometheus endpoint for Erlang allocator metrics.

### `kestrel` (baseline)

##### Instance-wide memory usage

<img width="1628" height="565" alt="grafana-kestrel-mem" src="https://github.com/user-attachments/assets/7a8d91d7-f958-42ba-a489-baa17b5fcdb1" />

##### Instance-wide CPU usage

<img width="1619" height="564" alt="grafana-kestrel-cpu" src="https://github.com/user-attachments/assets/166ecdc7-bb33-42ae-aebf-0d1ed8f81cd0" />

##### Erlang allocators

<img width="1629" height="611" alt="grafana-kestrel-erlang-alloc" src="https://github.com/user-attachments/assets/02dc33d0-022f-4054-b76a-73c25a249448" />

### `galactica` (this branch)

##### Instance-wide memory usage

<img width="1621" height="565" alt="grafana-galactica-mem" src="https://github.com/user-attachments/assets/c0f3d513-3195-447f-84d2-eb81efa00170" />

##### Instance-wide CPU usage

<img width="1622" height="566" alt="grafana-galactica-cpu" src="https://github.com/user-attachments/assets/7fa14f71-daa6-4cc7-bf34-10f903313761" />

##### Erlang allocators

<img width="1618" height="611" alt="grafana-galactica-erlang-alloc" src="https://github.com/user-attachments/assets/eacf2dee-6c85-46c2-b632-d8677540f1a0" />

---

</details>

We can see `kestrel` (baseline) pinned at around 95% CPU usage consistently, hovering at around 9-10 GB instance-wide memory usage and the VM aware of 3.5-4.5 GB of usage. And `galactica` (this branch) sitting at 50% CPU usage, around 7.5-8.5 GB instance-wide memory and the VM tracking around 2-3 GB of memory.

While the peak memory usage is reduced nicely, the main benefit is the CPU is loaded much less than before - I assume from performing less garbage collection.