### PR TITLE
prometheus_text_format: Fix argument order for `format_into/3` fun

### DIFF
--- a/src/formats/prometheus_text_format.erl
+++ b/src/formats/prometheus_text_format.erl
@@ -101,7 +101,7 @@ format_into_create_mf_callback_fn(Fmt) ->
             "\n"
         >>,
         Bin = render_metrics(Prologue, Name, Metrics),
-        put(?MODULE, Fmt(Bin, erase(?MODULE)))
+        put(?MODULE, Fmt(erase(?MODULE), Bin))
     end.
 
 ?DOC("""


### PR DESCRIPTION
The formatting function should take the state as the first argument and new data as the second. See `format/1` which passes in the trailing linefeed as the second argument. This doesn't make much difference when calling `format/1` because the swapped arguments only caused the metrics to be concatenated in reverse. But this fix is important for using `format_into/3` correctly, for example with `cowboy_req:stream_body/3`.